### PR TITLE
[Update] Adding support for new enum to indicate there are active sessions

### DIFF
--- a/AgentInterfaces/VmState.cs
+++ b/AgentInterfaces/VmState.cs
@@ -101,6 +101,12 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
         /// The game servers are exiting too quickly (potentially due to crashes).
         /// </summary>
         [ProtoEnum]
-        TooManyServerRestarts
+        TooManyServerRestarts,
+
+        /// <summary>
+        /// There are game servers with active sessions
+        /// </summary>
+        [ProtoEnum]
+        HasActiveSessions
     }
 }


### PR DESCRIPTION
This enum will be used to determine the action the session contoller in the agent will take when sending back responses for unassignment.