### PR TITLE
Move image pull verification into retry.

### DIFF
--- a/VmAgent.Core/VmAgent.Core.csproj
+++ b/VmAgent.Core/VmAgent.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>1.1.1</PackageVersion>
+    <PackageVersion>1.1.2</PackageVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageDescription>Helper library for LocalMultiplayerAgent, part of Azure PlayFab Multiplayer Servers</PackageDescription>
     <PackageProjectUrl>https://github.com/PlayFab/MpsAgent</PackageProjectUrl>


### PR DESCRIPTION
Moving the image pull verification to within the retry. We are seeing cases where the image pull doesn't work sometimes (that's still pending investigation).

We also noticed that the image layer extraction time doesn't get logged properly on occasion. It shows up as 0ms. Adding the full log from the streamed message to further debug this issue.