### PR TITLE
Add proto contract for VmNetworkConfiguration.

### DIFF
--- a/AgentInterfaces/AgentInterfaces.csproj
+++ b/AgentInterfaces/AgentInterfaces.csproj
@@ -9,7 +9,7 @@
     -->
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageId>PlayFab.MultiplayerServers.AgentInterfaces</PackageId>
-    <PackageVersion>5.1.1</PackageVersion>
+    <PackageVersion>5.1.2</PackageVersion>
     <PackageDescription>Helper library for LocalMultiplayerAgent, part of Azure PlayFab Multiplayer Servers </PackageDescription>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/AgentInterfaces/VmNetworkConfiguration.cs
+++ b/AgentInterfaces/VmNetworkConfiguration.cs
@@ -1,38 +1,51 @@
 ﻿namespace Microsoft.Azure.Gaming.AgentInterfaces
 {
+    using ProtoBuf;
+
+    [ProtoContract]
     public class VmNetworkConfiguration
     {
+        [ProtoMember(1)]
+        public string VmName { get; set; }
+
         /// <summary>
         /// The public Ipv4 address that can be used to connect to the VM.
         /// </summary>
+        [ProtoMember(2)]
         public string PublicIpv4Address { get; set; }
 
         /// <summary>
         /// The fully qualified domain name for the VM. Useful for scenarios involving IPv6 (where the Ipv4 address cannot be used).
         /// </summary>
+        [ProtoMember(3)]
         public string Fqdn { get; set; }
 
         /// <summary>
         /// A list of endpoints on the VM which can be assigned to the game servers so that the game clients can connect to them.
         /// </summary>
+        [ProtoMember(4)]
         public Endpoint[] Endpoints { get; set; }
     }
 
+    [ProtoContract]
     public class Endpoint
     {
         /// <summary>
         /// The publicly accessible port exposed on the software load balancer.
         /// </summary>
+        [ProtoMember(1)]
         public int FrontEndPort { get; set; }
 
         /// <summary>
         /// The port on the Node that the FrontEndPort is mapped to.
         /// </summary>
+        [ProtoMember(2)]
         public int BackEndPort { get; set; }
 
         /// <summary>
         /// The protocol for the network traffic.
         /// </summary>
+        [ProtoMember(3)]
         public string Protocol { get; set; }
     }
 }


### PR DESCRIPTION
GRPC heartbeats require ProtoContract to be applied to all properties recursively.
Also added a VMName property that can be used to correlate a VM with its name in a VMSS (VMSS re-uses an instance number, so it cannot be used a global identifier). However, the Id obtained from Metadata service has no connection to any identifier in VMSS. The vmName obtained from metadata service is the instance number of that VM in the VMSS. We will use that to map the VM to the instance in VMSS (when we need to remove a VM from VMSS by providing the instance number)