### PR TITLE
Example for running on MacOs

### DIFF
--- a/LocalMultiplayerAgent/Config/MultiplayerSettingsValidator.cs
+++ b/LocalMultiplayerAgent/Config/MultiplayerSettingsValidator.cs
@@ -33,17 +33,17 @@ namespace Microsoft.Azure.Gaming.LocalMultiplayerAgent.Config
                 throw new Exception("OutputFolder or TitleId not found. Call SetDefaultsIfNotSpecified() before this method");
             }
 
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                Console.WriteLine("Running LocalMultiplayerAgent on Linux is not supported yet.");
-                return false;
-            }
-
-            if (Globals.GameServerEnvironment == GameServerEnvironment.Linux && !_settings.RunContainer)
-            {
-                Console.WriteLine("The specified settings are invalid. Using Linux Game Servers requires running in a container.");
-                return false;
-            }
+            // if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            // {
+            //     Console.WriteLine("Running LocalMultiplayerAgent on Linux is not supported yet.");
+            //     return false;
+            // }
+            //
+            // if (Globals.GameServerEnvironment == GameServerEnvironment.Linux && !_settings.RunContainer)
+            // {
+            //     Console.WriteLine("The specified settings are invalid. Using Linux Game Servers requires running in a container.");
+            //     return false;
+            // }
 
             string startGameCommand;
 

--- a/LocalMultiplayerAgent/Properties/launchSettings.json
+++ b/LocalMultiplayerAgent/Properties/launchSettings.json
@@ -18,6 +18,7 @@
     "LocalMultiplayerAgent": {
       "commandName": "Project",
       "launchBrowser": true,
+      "commandLineArgs": "-lcow",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/VmAgent.Core/Interfaces/ProcessRunner.cs
+++ b/VmAgent.Core/Interfaces/ProcessRunner.cs
@@ -92,7 +92,11 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
 
         private (string, string) GetExecutableAndArguments(SessionHostsStartInfo sessionHostsStartInfo, int instanceNumber)
         {
-            string[] parts = sessionHostsStartInfo.StartGameCommand.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            var command = sessionHostsStartInfo.StartGameCommand.Replace("\\ ", "\\SPACE");
+            string[] parts = command
+                .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+                .Select(part => part.Replace("\\SPACE", " "))
+                .ToArray();
             string localPathForAsset0 = sessionHostsStartInfo.UseReadOnlyAssets ? _vmConfiguration.GetAssetExtractionFolderPathForSessionHost(0, 0) :
                 _vmConfiguration.GetAssetExtractionFolderPathForSessionHost(instanceNumber, 0);
 


### PR DESCRIPTION
Hi! I understand MacOS isn't officially supported but I thought i'd share the changes I needed to make in order to run the agent on my MacBook.

I had to make the following changes to the configuration file:

- Disable RunContainer
- The StartGameCommand needed to include the path of the actual binary for the game, not the package. 
For example: 
"ProcessStartParameters": {
        "StartGameCommand": "/Users/example/Example.app/Contents/MacOS/Example -nographics -batchmode"
    },

Our Unity Game's product name includes spaces, so I needed to escape these in the ProcessRunner. Otherwise, the StartGameCommand would be interpreted incorrectly.

It works great, thanks for providing the local agent!