### PR TITLE
Bport/create dump folder

### DIFF
--- a/LocalMultiplayerAgent/NoOpSessionHostManager.cs
+++ b/LocalMultiplayerAgent/NoOpSessionHostManager.cs
@@ -147,5 +147,10 @@ namespace Microsoft.Azure.Gaming.LocalMultiplayerAgent
         {
             return true;
         }
+
+        public bool SignalDumpFoundAndCheckIfThrottled(string sessionHostId)
+        {
+            return false;
+        }
     }
 }

--- a/LocalMultiplayerAgent/NoOpSessionHostManager.cs
+++ b/LocalMultiplayerAgent/NoOpSessionHostManager.cs
@@ -156,6 +156,8 @@ namespace Microsoft.Azure.Gaming.LocalMultiplayerAgent
 
         public bool SignalDumpFoundAndCheckIfThrottled(string sessionHostId)
         {
+            // don't do anything to signal that a dump was found,
+            // and don't throttle
             return false;
         }
     }

--- a/VmAgent.Core/Interfaces/BaseSessionHostRunner.cs
+++ b/VmAgent.Core/Interfaces/BaseSessionHostRunner.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.ContainerEngines
     using Microsoft.Azure.Gaming.AgentInterfaces;
     using Microsoft.Azure.Gaming.VmAgent.Core;
     using System.IO;
+    using System;
 
     public abstract class BaseSessionHostRunner : ISessionHostRunner
     {
@@ -86,6 +87,10 @@ namespace Microsoft.Azure.Gaming.VmAgent.ContainerEngines
                     // in the dumps folder, and then the game server crashed. The background process could theoretically still be
                     // running, which would prevent us from processing the dump files.
                     _logger.LogWarning($"Unable to process dump files on session host {id}: {ex}");
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError($"Unexpected error processing dump files on session host {id}: {ex}");
                 }
             }
         }

--- a/VmAgent.Core/Interfaces/BaseSessionHostRunner.cs
+++ b/VmAgent.Core/Interfaces/BaseSessionHostRunner.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.ContainerEngines
                     // I think we'd only end up here if a game server spun up a background process that had a lock on some files
                     // in the dumps folder, and then the game server crashed. The background process could theoretically still be
                     // running, which would prevent us from processing the dump files.
-                    _logger.LogWarning($"Unable to process dump files: {ex}");
+                    _logger.LogWarning($"Unable to process dump files on session host {id}: {ex}");
                 }
             }
         }

--- a/VmAgent.Core/Interfaces/BaseSessionHostRunner.cs
+++ b/VmAgent.Core/Interfaces/BaseSessionHostRunner.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Azure.Gaming.VmAgent.ContainerEngines
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Gaming.VmAgent.Model;
+    using Core.Interfaces;
+
+    using Microsoft.Azure.Gaming.AgentInterfaces;
+    using Microsoft.Azure.Gaming.VmAgent.Core;
+    using System.IO;
+
+    public abstract class BaseSessionHostRunner : ISessionHostRunner
+    {
+        protected readonly MultiLogger _logger;
+
+        protected readonly VmConfiguration _vmConfiguration;
+
+        protected readonly ISystemOperations _systemOperations;
+
+        protected BaseSessionHostRunner(
+            VmConfiguration vmConfiguration,
+            MultiLogger logger,
+            ISystemOperations systemOperations)
+        {
+            _logger = logger;
+            _vmConfiguration = vmConfiguration;
+            _systemOperations = systemOperations;
+        }
+
+        abstract public Task CollectLogs(string id, string logsFolder, ISessionHostManager sessionHostManager);
+
+        abstract public Task<SessionHostInfo> CreateAndStart(int instanceNumber, GameResourceDetails gameResourceDetails, ISessionHostManager sessionHostManager);
+
+        abstract public Task DeleteResources(SessionHostsStartInfo sessionHostsStartInfo);
+
+        abstract public string GetVmAgentIpAddress();
+
+        abstract public Task<IEnumerable<string>> List();
+
+        abstract public Task RetrieveResources(SessionHostsStartInfo sessionHostsStartInfo);
+
+        abstract public Task<bool> TryDelete(string id);
+
+        abstract public Task WaitOnServerExit(string containerId);
+
+        protected void ProcessDumps(string id, string logsFolder, ISessionHostManager sessionHostManager)
+        {
+            if (sessionHostManager.VmAgentSettings.EnableCrashDumpProcessing)
+            {
+                try
+                {
+                    string dumpFolder = Path.Combine(logsFolder, VmDirectories.GameDumpsFolderName);
+                    bool dumpFound = false;
+                    try
+                    {
+                        if (!_systemOperations.IsDirectoryEmpty(dumpFolder))
+                        {
+                            dumpFound = true;
+                        }
+                        else
+                        {
+                            // If dumps folder is empty, delete it
+                            _systemOperations.DeleteDirectoryIfExists(dumpFolder);
+                        }
+                    }
+                    catch (DirectoryNotFoundException) { }
+
+                    if (dumpFound)
+                    {
+                        bool shouldDeleteDump = sessionHostManager.SignalDumpFoundAndCheckIfThrottled(id);
+                        if (shouldDeleteDump)
+                        {
+                            _systemOperations.DeleteDirectoryIfExists(dumpFolder);
+                            _systemOperations.CreateDirectory(dumpFolder);
+                            string readmePath = Path.Combine(dumpFolder, "readme.txt");
+                            _systemOperations.FileWriteAllText(readmePath, $"The contents of \"{VmDirectories.GameDumpsFolderName}\" have been deleted due to throttling.");
+                        }
+                    }
+                }
+                catch (IOException ex)
+                {
+                    // I think we'd only end up here if a game server spun up a background process that had a lock on some files
+                    // in the dumps folder, and then the game server crashed. The background process could theoretically still be
+                    // running, which would prevent us from processing the dump files.
+                    _logger.LogWarning($"Unable to process dump files: {ex}");
+                }
+            }
+        }
+    }
+}

--- a/VmAgent.Core/Interfaces/DockerContainerEngine.cs
+++ b/VmAgent.Core/Interfaces/DockerContainerEngine.cs
@@ -53,7 +53,6 @@ namespace Microsoft.Azure.Gaming.VmAgent.ContainerEngines
             IDockerClient dockerClient = null)
             : base (vmConfiguration, logger, systemOperations)
         {
-            // This can be moved to dependency injection pattern when unit tests are added for this class.
             _dockerClient = dockerClient ?? CreateDockerClient();
         }
 

--- a/VmAgent.Core/Interfaces/DockerContainerEngine.cs
+++ b/VmAgent.Core/Interfaces/DockerContainerEngine.cs
@@ -437,6 +437,10 @@ namespace Microsoft.Azure.Gaming.VmAgent.ContainerEngines
             string logFolderPathOnVm = Path.Combine(_vmConfiguration.VmDirectories.GameLogsRootFolderVm, logFolderId);
             _systemOperations.CreateDirectory(logFolderPathOnVm);
 
+            // Create the dumps folder as a subfolder of the logs folder
+            string dumpFolderPathOnVm = Path.Combine(logFolderPathOnVm, VmDirectories.GameDumpsFolderName);
+            _systemOperations.CreateDirectory(dumpFolderPathOnVm);
+
             // Set up the log folder. Maps D:\GameLogs\{logFolderId} on the container host to C:\GameLogs on the container.
             // TODO: TBD whether the log folder should be taken as input from developer during ingestion.
             volumeBindings.Add($"{logFolderPathOnVm}:{_vmConfiguration.VmDirectories.GameLogsRootFolderContainer}");
@@ -496,6 +500,16 @@ namespace Microsoft.Azure.Gaming.VmAgent.ContainerEngines
                         _systemOperations.FileCopy(dockerLogsPath, destinationFileName);
                     }   
                 }
+
+                try
+                {
+                    string dumpFolder = Path.Combine(logsFolder, VmDirectories.GameDumpsFolderName);
+                    if (!Directory.EnumerateFileSystemEntries(dumpFolder).Any())
+                    {
+                        Directory.Delete(dumpFolder);
+                    }
+                }
+                catch (DirectoryNotFoundException) { }
             }
             catch (DockerContainerNotFoundException)
             {

--- a/VmAgent.Core/Interfaces/ISessionHostConfiguration.cs
+++ b/VmAgent.Core/Interfaces/ISessionHostConfiguration.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
     {
         void Create(int instanceNumber, string sessionHostUniqueId, string agentEndpoint, VmConfiguration vmConfiguration, string logFoldeId);
 
-        IDictionary<string, string> GetEnvironmentVariablesForSessionHost(int instanceNumber, string logFolderId);
+        IDictionary<string, string> GetEnvironmentVariablesForSessionHost(int instanceNumber, string logFolderId, VmAgentSettings agentSettings);
 
         IList<PortMapping> GetPortMappings(int instanceNumber);
     }

--- a/VmAgent.Core/Interfaces/ISessionHostManager.cs
+++ b/VmAgent.Core/Interfaces/ISessionHostManager.cs
@@ -67,5 +67,12 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
         bool IsStartupScriptExecutionComplete();
 
         bool IsUnassignable();
+
+        /// <summary>
+        /// Signals that a crash dump was found in the given SessionHost's logs folder, and checks
+        /// if the crash dump should be deleted due to throttling.
+        /// </summary>
+        /// <returns>True if the crash dump should be deleted, false otherwise</returns>
+        bool SignalDumpFoundAndCheckIfThrottled(string sessionHostId);
     }
 }

--- a/VmAgent.Core/Interfaces/ISystemOperations.cs
+++ b/VmAgent.Core/Interfaces/ISystemOperations.cs
@@ -41,6 +41,8 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
 
         void DeleteDirectoryIfExists(string pathToDirectory);
 
+        bool IsDirectoryEmpty(string pathToDirectory);
+
         void DeleteFile(string filePath);
 
         long FileInfoLength(string path);

--- a/VmAgent.Core/Interfaces/ProcessRunner.cs
+++ b/VmAgent.Core/Interfaces/ProcessRunner.cs
@@ -44,9 +44,12 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
             string logFolderPathOnVm = Path.Combine(_vmConfiguration.VmDirectories.GameLogsRootFolderVm, sessionHostUniqueId);
             _systemOperations.CreateDirectory(logFolderPathOnVm);
 
-            // Create the dumps folder as a subfolder of the logs folder
-            string dumpFolderPathOnVm = Path.Combine(logFolderPathOnVm, VmDirectories.GameDumpsFolderName);
-            _systemOperations.CreateDirectory(dumpFolderPathOnVm);
+            if (sessionHostManager.VmAgentSettings.EnableCrashDumpProcessing)
+            {
+                // Create the dumps folder as a subfolder of the logs folder
+                string dumpFolderPathOnVm = Path.Combine(logFolderPathOnVm, VmDirectories.GameDumpsFolderName);
+                _systemOperations.CreateDirectory(dumpFolderPathOnVm);
+            }
 
             ISessionHostConfiguration sessionHostConfiguration = new SessionHostProcessConfiguration(_vmConfiguration, _logger, _systemOperations, sessionHostStartInfo);
             string configFolderPathOnVm = _vmConfiguration.GetConfigRootFolderForSessionHost(instanceNumber);
@@ -57,7 +60,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
             processStartInfo.FileName = executableFileName;
             processStartInfo.Arguments = arguments;
             processStartInfo.WorkingDirectory = sessionHostStartInfo.GameWorkingDirectory ?? Path.GetDirectoryName(executableFileName);
-            processStartInfo.Environment.AddRange(sessionHostConfiguration.GetEnvironmentVariablesForSessionHost(instanceNumber, sessionHostUniqueId));
+            processStartInfo.Environment.AddRange(sessionHostConfiguration.GetEnvironmentVariablesForSessionHost(instanceNumber, sessionHostUniqueId, sessionHostManager.VmAgentSettings));
 
             _logger.LogInformation($"Starting process for session host with instance number {instanceNumber} and process info: FileName - {executableFileName}, Args - {arguments}.");
 

--- a/VmAgent.Core/Interfaces/SessionHostConfigurationBase.cs
+++ b/VmAgent.Core/Interfaces/SessionHostConfigurationBase.cs
@@ -84,21 +84,18 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
             _sessionHostsStartInfo = sessionHostsStartInfo;
         }
 
-        public IDictionary<string, string> GetEnvironmentVariablesForSessionHost(int instanceNumber, string logFolderId)
+        public IDictionary<string, string> GetEnvironmentVariablesForSessionHost(int instanceNumber, string logFolderId, VmAgentSettings agentSettings)
         {
             VmConfiguration.ParseAssignmentId(_sessionHostsStartInfo.AssignmentId, out Guid titleId, out Guid deploymentId, out string region);
 
             // Note that most of these are being provided based on customer request
-            return new Dictionary<string, string>()
+            var environmentVariables = new Dictionary<string, string>()
             {
                 {
                     ConfigFileEnvVariable, GetGsdkConfigFilePath(_sessionHostsStartInfo.AssignmentId, instanceNumber)
                 },
                 {
                     LogsDirectoryEnvVariable, GetLogFolder(logFolderId, VmConfiguration)
-                },
-                {
-                    DumpsDirectoryEnvVariable, GetDumpFolder(logFolderId, VmConfiguration)
                 },
                 {
                     SharedContentFolderEnvVariable, GetSharedContentFolderPath()
@@ -125,6 +122,13 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
                     PublicIPv4AddressEnvVariable, _sessionHostsStartInfo.PublicIpV4Address
                 }
             };
+
+            if (agentSettings.EnableCrashDumpProcessing)
+            {
+                environmentVariables.Add(DumpsDirectoryEnvVariable, GetDumpFolder(logFolderId, VmConfiguration));
+            }
+
+            return environmentVariables;
         }
 
         public void Create(int instanceNumber, string sessionHostUniqueId, string agentEndpoint, VmConfiguration vmConfiguration, string logFolderId)

--- a/VmAgent.Core/Interfaces/SessionHostConfigurationBase.cs
+++ b/VmAgent.Core/Interfaces/SessionHostConfigurationBase.cs
@@ -53,6 +53,12 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
         /// </summary>
         private const string LogsDirectoryEnvVariable = "PF_SERVER_LOG_DIRECTORY";
 
+        /// <summary>
+        /// An environment variable capturing the crash dumps folder for a game server.
+        /// This folder is a subfolder of PF_SERVER_LOG_DIRECTORY.
+        /// </summary>
+        private const string DumpsDirectoryEnvVariable = "PF_SERVER_DUMP_DIRECTORY";
+
         // Not sure if this is needed yet.
         private const string DefaultExePath = @"C:\app\";
 
@@ -90,6 +96,9 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
                 },
                 {
                     LogsDirectoryEnvVariable, GetLogFolder(logFolderId, VmConfiguration)
+                },
+                {
+                    DumpsDirectoryEnvVariable, GetDumpFolder(logFolderId, VmConfiguration)
                 },
                 {
                     SharedContentFolderEnvVariable, GetSharedContentFolderPath()
@@ -162,6 +171,11 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
         }
 
         protected abstract string GetLogFolder(string logFolderId, VmConfiguration vmConfiguration);
+
+        protected string GetDumpFolder(string logFolderId, VmConfiguration vmConfiguration)
+        {
+            return Path.Combine(GetLogFolder(logFolderId, vmConfiguration), VmDirectories.GameDumpsFolderName);
+        }
 
         protected abstract string GetSharedContentFolder(VmConfiguration vmConfiguration);
 

--- a/VmAgent.Core/Interfaces/SystemOperations.cs
+++ b/VmAgent.Core/Interfaces/SystemOperations.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
     using System.Diagnostics;
     using System.IO;
     using System.IO.Compression;
+    using System.Linq;
     using System.Net;
     using System.Runtime.InteropServices;
     using System.Security.Cryptography.X509Certificates;
@@ -66,6 +67,11 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
             {
                 Directory.Delete(pathToDirectory, true);
             }
+        }
+
+        public bool IsDirectoryEmpty(string pathToDirectory)
+        {
+            return Directory.EnumerateFileSystemEntries(pathToDirectory).Any();
         }
 
         public Stream OpenFileForRead(string filePath)

--- a/VmAgent.Core/Interfaces/SystemOperations.cs
+++ b/VmAgent.Core/Interfaces/SystemOperations.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
 
         public bool IsDirectoryEmpty(string pathToDirectory)
         {
-            return Directory.EnumerateFileSystemEntries(pathToDirectory).Any();
+            return !Directory.EnumerateFileSystemEntries(pathToDirectory).Any();
         }
 
         public Stream OpenFileForRead(string filePath)

--- a/VmAgent.Core/VmDirectories.cs
+++ b/VmAgent.Core/VmDirectories.cs
@@ -43,9 +43,9 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core
         public string AgentStateFile { get; }
 
         public string AgentStateTempFile { get; }
-        
+
         public string HostConfigOverrideFile { get; }
-        
+
         public string AgentLogsFolder { get; }
 
         // A folder that is accessible by all games on the Vm, potentially for content that's downloaded once but used multiple times.
@@ -56,6 +56,8 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core
         public string GameLogsRootFolderVm { get; }
 
         public string GameLogsRootFolderContainer { get; set; }
+
+        public const string GameDumpsFolderName = "_dumps";
 
         public string AssetExtractionRootFolderVm { get; }
 


### PR DESCRIPTION
On startup, creates a `_dumps` folder inside of the logs folder and creates a `PF_SERVER_DUMPS_DIRECTORY` environment variable that points to it. 
On exit, deletes the `_dumps` folder if it's empty (this way, developers won't have an empty folder in all of their log archives). If it's not empty, a call is made to the `ISessionHostManager` to signal that a dump was found and to determine if dump processing has been throttled. If it's been throttled, it deletes the dump and replaces it with a `readme.txt` file with a short explanation.
LocalMultiplayerAgent uses a `NoopSessionHostManager`, which doesn't do any actual dump signaling or throttling. That logic will be implemented in our internal VmAgent repo.

All of these changes are put behind the EnableCrashDumpProcessing setting.