### PR TITLE
Added WindowsCrashDumpConfiguration to SessionHostsStartInfo

### DIFF
--- a/AgentInterfaces/AgentInterfaces.csproj
+++ b/AgentInterfaces/AgentInterfaces.csproj
@@ -9,7 +9,7 @@
     -->
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageId>PlayFab.MultiplayerServers.AgentInterfaces</PackageId>
-    <PackageVersion>5.2.1</PackageVersion>
+    <PackageVersion>5.3.0</PackageVersion>
     <PackageDescription>Helper library for LocalMultiplayerAgent, part of Azure PlayFab Multiplayer Servers </PackageDescription>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/AgentInterfaces/SessionHostsStartInfo.cs
+++ b/AgentInterfaces/SessionHostsStartInfo.cs
@@ -115,6 +115,12 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
         public WindowsInstrumentationConfiguration WindowsInstrumentationConfiguration { get; set; }
 
         /// <summary>
+        /// Configuration for automatic crash dump capturing on a Windows VM.
+        /// Ignored on Linux VMs
+        /// </summary>
+        public WindowsCrashDumpConfiguration WindowsCrashDumpConfiguration { get; set; }
+
+        /// <summary>
         /// The working directory on Windows VM. If this is not provided
         /// we will do a best effort to retrieve it from the start game
         /// command.
@@ -160,6 +166,27 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
         /// Is Windows instrumentation enabled
         /// </summary>
         public bool IsEnabled { get; set; }
+    }
+
+    /// <summary>
+    /// Configuration for capturing crash dumps on the VM.
+    /// </summary>
+    public class WindowsCrashDumpConfiguration
+    {
+        /// <summary>
+        /// Is automatic crash dump capturing enabled
+        /// </summary>
+        public bool IsEnabled;
+
+        /// <summary>
+        /// See https://docs.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps for valid values.
+        /// </summary>
+        public int DumpType { get; set; }
+
+        /// <summary>
+        /// See https://docs.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps for valid values.
+        /// </summary>
+        public int CustomDumpFlags { get; set; }
     }
 
     public class MonitoringApplicationConfiguration


### PR DESCRIPTION
Now ControlPlane can send the values needed when the vm is assigned so that VmAgent can set the appropriate registry keys whenever it creates a Windows Container. When set, these keys will cause crash dumps to automatically get collected and placed in the _dumps folder.