### PR TITLE
Emmap/local agent log path

### DIFF
--- a/VmAgent.Core/Interfaces/SessionHostContainerConfiguration.cs
+++ b/VmAgent.Core/Interfaces/SessionHostContainerConfiguration.cs
@@ -46,7 +46,11 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
         {
             // The VM host folder corresponding to the logFolderId gets mounted under this path for each container.
             // So the logFolderId itself isn't of much significance within the container.
-            return vmConfiguration.VmDirectories.GameLogsRootFolderContainer + Path.AltDirectorySeparatorChar;
+
+            string vmDirGameLogPath = vmConfiguration.VmDirectories.GameLogsRootFolderContainer;
+            char pathSeperator = vmDirGameLogPath.StartsWith("/data/") ? Path.AltDirectorySeparatorChar : Path.DirectorySeparatorChar;
+
+            return vmDirGameLogPath + pathSeperator;
         }
 
         protected override string GetSharedContentFolder(VmConfiguration vmConfiguration)

--- a/VmAgent.Core/Interfaces/SessionHostContainerConfiguration.cs
+++ b/VmAgent.Core/Interfaces/SessionHostContainerConfiguration.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
         {
             // The VM host folder corresponding to the logFolderId gets mounted under this path for each container.
             // So the logFolderId itself isn't of much significance within the container.
-            return vmConfiguration.VmDirectories.GameLogsRootFolderContainer + Path.DirectorySeparatorChar;
+            return vmConfiguration.VmDirectories.GameLogsRootFolderContainer + Path.AltDirectorySeparatorChar;
         }
 
         protected override string GetSharedContentFolder(VmConfiguration vmConfiguration)


### PR DESCRIPTION
Game log path should not include "\" when **LocalMultiplayerAgent** creates logs for **Linux container** ( Linux cannot support "\").
 
 