### PR TITLE
Fix serialization clobbering dictionary keys.

### DIFF
--- a/VmAgent.Core.UnitTests/SerializationTests.cs
+++ b/VmAgent.Core.UnitTests/SerializationTests.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace VmAgent.Core.UnitTests
+{
+    using FluentAssertions;
+    using Microsoft.Azure.Gaming.VmAgent.Core;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Newtonsoft.Json;
+
+    [TestClass]
+    public class SerializationTests
+    {
+        [TestMethod]
+        [TestCategory("BVT")]
+        public void JsonSerializeDoesNotClobberDictionaryKeys()
+        {
+            var sampleObject = new SampleObjectWithDictionary()
+            {
+                Metadata = new Dictionary<string, string>()
+                {
+                    {"KEYWITHALLCAPS", "value1"},
+                    {"keywithallsmallcase", "value2" },
+                    {"keyWithMixedCase", "value3" }
+                }
+            };
+
+            string serializedValue = JsonConvert.SerializeObject(sampleObject, CommonSettings.JsonSerializerSettings);
+            SampleObjectWithDictionary deserializedObject =
+                JsonConvert.DeserializeObject<SampleObjectWithDictionary>(serializedValue, CommonSettings.JsonSerializerSettings);
+            deserializedObject.Should().BeEquivalentTo(sampleObject);
+        }
+
+        private class SampleObjectWithDictionary
+        {
+            public IDictionary<string, string> Metadata { get; set; }
+        }
+    }
+}

--- a/VmAgent.Core.UnitTests/VmAgent.Core.UnitTests.csproj
+++ b/VmAgent.Core.UnitTests/VmAgent.Core.UnitTests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="Moq" Version="4.11.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />

--- a/VmAgent.Core/CommonSettings.cs
+++ b/VmAgent.Core/CommonSettings.cs
@@ -12,9 +12,9 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core
     {
         public const string NullStringValue = "NULL";
 
-        public static JsonSerializerSettings JsonSerializerSettings = new JsonSerializerSettings
+        public static readonly JsonSerializerSettings JsonSerializerSettings = new JsonSerializerSettings
         {
-            ContractResolver = new CamelCasePropertyNamesContractResolver(),
+            ContractResolver = new CamelCasePropertyNamesContractResolver() { NamingStrategy = new CamelCaseNamingStrategy(processDictionaryKeys: false, overrideSpecifiedNames: false) },
             Converters = new List<JsonConverter> { new StringEnumConverter() },
             DefaultValueHandling = DefaultValueHandling.Ignore,
             NullValueHandling = NullValueHandling.Ignore

--- a/VmAgent.Core/VmAgent.Core.csproj
+++ b/VmAgent.Core/VmAgent.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>1.3.1</PackageVersion>
+    <PackageVersion>1.3.2</PackageVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageDescription>Helper library for LocalMultiplayerAgent, part of Azure PlayFab Multiplayer Servers</PackageDescription>
     <PackageProjectUrl>https://github.com/PlayFab/MpsAgent</PackageProjectUrl>


### PR DESCRIPTION
The camelcase serialization seems to be clobbering dictionary keys by default. Explicitly setting the naming strategy to not do that.