### PR TITLE
Support running Linux Process

### DIFF
--- a/LocalMultiplayerAgent/Config/MultiplayerSettingsValidator.cs
+++ b/LocalMultiplayerAgent/Config/MultiplayerSettingsValidator.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Gaming.LocalMultiplayerAgent.Config
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                Console.WriteLine("Running LocalMultiplayerAgent is not yet supported on MacOS.");
+                Console.WriteLine("Running LocalMultiplayerAgent is not yet supported on MacOS. We would be happy to accept PRs to make it work!");
                 return false;
             }
 

--- a/LocalMultiplayerAgent/Config/MultiplayerSettingsValidator.cs
+++ b/LocalMultiplayerAgent/Config/MultiplayerSettingsValidator.cs
@@ -35,9 +35,15 @@ namespace Microsoft.Azure.Gaming.LocalMultiplayerAgent.Config
                 throw new Exception("OutputFolder or TitleId not found. Call SetDefaultsIfNotSpecified() before this method");
             }
 
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                Console.WriteLine("Running LocalMultiplayerAgent is not yet supported on MacOS.");
+                return false;
+            }
+
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && _settings.RunContainer)
             {
-                Console.WriteLine("Running LocalMultiplayerAgent as container mode on Linux is not supported yet.");
+                Console.WriteLine("Running LocalMultiplayerAgent as container mode is not yet supported on Linux. Please set RunContainer to false in MultiplayerSettings.json");
                 return false;
             }
 

--- a/LocalMultiplayerAgent/Config/MultiplayerSettingsValidator.cs
+++ b/LocalMultiplayerAgent/Config/MultiplayerSettingsValidator.cs
@@ -35,11 +35,11 @@ namespace Microsoft.Azure.Gaming.LocalMultiplayerAgent.Config
                 throw new Exception("OutputFolder or TitleId not found. Call SetDefaultsIfNotSpecified() before this method");
             }
 
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                Console.WriteLine("Running LocalMultiplayerAgent on Linux is not supported yet.");
-                return false;
-            }
+            //if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            //{
+            //    Console.WriteLine("Running LocalMultiplayerAgent on Linux is not supported yet.");
+            //    return false;
+            //}
 
             if (Globals.GameServerEnvironment == GameServerEnvironment.Linux && !_settings.RunContainer)
             {

--- a/LocalMultiplayerAgent/Config/MultiplayerSettingsValidator.cs
+++ b/LocalMultiplayerAgent/Config/MultiplayerSettingsValidator.cs
@@ -35,11 +35,11 @@ namespace Microsoft.Azure.Gaming.LocalMultiplayerAgent.Config
                 throw new Exception("OutputFolder or TitleId not found. Call SetDefaultsIfNotSpecified() before this method");
             }
 
-            //if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            //{
-            //    Console.WriteLine("Running LocalMultiplayerAgent on Linux is not supported yet.");
-            //    return false;
-            //}
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && _settings.RunContainer)
+            {
+                Console.WriteLine("Running LocalMultiplayerAgent as container mode on Linux is not supported yet.");
+                return false;
+            }
 
             if (Globals.GameServerEnvironment == GameServerEnvironment.Linux && !_settings.RunContainer)
             {

--- a/LocalMultiplayerAgent/Globals.cs
+++ b/LocalMultiplayerAgent/Globals.cs
@@ -29,12 +29,6 @@ namespace Microsoft.Azure.Gaming.LocalMultiplayerAgent
             new MultiLogger(Logger, new TelemetryClient(TelemetryConfiguration.CreateDefault()));
 
         public static GameServerEnvironment GameServerEnvironment { get; set; }
-
-        public const string ZipExtension = ".zip";
-
-        public const string TarExtension = ".tar";
-
-        public const string TarGZipExtension = ".tar.gz";
     }
 
     public enum GameServerEnvironment

--- a/LocalMultiplayerAgent/Globals.cs
+++ b/LocalMultiplayerAgent/Globals.cs
@@ -30,6 +30,11 @@ namespace Microsoft.Azure.Gaming.LocalMultiplayerAgent
 
         public static GameServerEnvironment GameServerEnvironment { get; set; }
 
+        public const string ZipExtension = ".zip";
+
+        public const string TarExtension = ".tar";
+
+        public const string TarGZipExtension = ".tar.gz";
     }
 
     public enum GameServerEnvironment

--- a/LocalMultiplayerAgent/MultiplayerServerManager.cs
+++ b/LocalMultiplayerAgent/MultiplayerServerManager.cs
@@ -32,13 +32,13 @@ namespace Microsoft.Azure.Gaming.LocalMultiplayerAgent
             VmConfiguration vmConfiguration,
             MultiLogger logger,
             ISessionHostRunnerFactory sessionHostRunnerFactory,
-            BasicAssetExtractor basicAssetExtractor)
+            BasicAssetExtractor basicAssetExtractor = null)
         {
             _sessionHostRunnerFactory = sessionHostRunnerFactory;
             _systemOperations = systemOperations;
             _logger = logger;
             _vmConfiguration = vmConfiguration;
-            _basicAssetExtractor = basicAssetExtractor;
+            _basicAssetExtractor = new BasicAssetExtractor(_systemOperations, _logger);
         }
 
         public async Task CreateAndStartContainerWaitForExit(SessionHostsStartInfo startParameters)

--- a/LocalMultiplayerAgent/MultiplayerServerManager.cs
+++ b/LocalMultiplayerAgent/MultiplayerServerManager.cs
@@ -54,8 +54,6 @@ namespace Microsoft.Azure.Gaming.LocalMultiplayerAgent
                 }
             }
 
-            BasicAssetExtractor.Instance = new BasicAssetExtractor(_systemOperations, _logger, Globals.ZipExtension, Globals.TarExtension);
-
             DownloadAndExtractAllAssets(startParameters);
             DownloadGameCertificates(startParameters);
 
@@ -153,7 +151,7 @@ namespace Microsoft.Azure.Gaming.LocalMultiplayerAgent
         {
             string assetFileName = _vmConfiguration.GetAssetDownloadFileName(assetDetail.assetPath);
 
-            BasicAssetExtractor.Instance.ExtractAssets(assetFileName,
+            _basicAssetExtractor.ExtractAssets(assetFileName,
                 _vmConfiguration.GetAssetExtractionFolderPathForSessionHost(0, assetDetail.assetNumber));
         }
     }

--- a/LocalMultiplayerAgent/Program.cs
+++ b/LocalMultiplayerAgent/Program.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.Gaming.LocalMultiplayerAgent
     using Newtonsoft.Json;
     using VmAgent.Core;
     using VmAgent.Core.Interfaces;
+    using Microsoft.Azure.Gaming.VmAgent.Core.Dependencies;
 
     public class Program
     {
@@ -83,7 +84,7 @@ namespace Microsoft.Azure.Gaming.LocalMultiplayerAgent
 
             Globals.SessionConfig = settings.SessionConfig ?? new SessionConfig() { SessionId = Guid.NewGuid() };
             Console.WriteLine($"{string.Join(", ", Globals.SessionConfig.InitialPlayers)}");
-            await new MultiplayerServerManager(SystemOperations.Default, Globals.VmConfiguration, Globals.MultiLogger, SessionHostRunnerFactory.Instance)
+            await new MultiplayerServerManager(SystemOperations.Default, Globals.VmConfiguration, Globals.MultiLogger, SessionHostRunnerFactory.Instance, BasicAssetExtractor.Instance)
                 .CreateAndStartContainerWaitForExit(settings.ToSessionHostsStartInfo());
 
             await host.StopAsync();

--- a/LocalMultiplayerAgent/Program.cs
+++ b/LocalMultiplayerAgent/Program.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Gaming.LocalMultiplayerAgent
 
             Globals.SessionConfig = settings.SessionConfig ?? new SessionConfig() { SessionId = Guid.NewGuid() };
             Console.WriteLine($"{string.Join(", ", Globals.SessionConfig.InitialPlayers)}");
-            await new MultiplayerServerManager(SystemOperations.Default, Globals.VmConfiguration, Globals.MultiLogger, SessionHostRunnerFactory.Instance, BasicAssetExtractor.Instance)
+            await new MultiplayerServerManager(SystemOperations.Default, Globals.VmConfiguration, Globals.MultiLogger, SessionHostRunnerFactory.Instance)
                 .CreateAndStartContainerWaitForExit(settings.ToSessionHostsStartInfo());
 
             await host.StopAsync();

--- a/LocalMultiplayerAgent/Startup.cs
+++ b/LocalMultiplayerAgent/Startup.cs
@@ -12,6 +12,9 @@ namespace Microsoft.Azure.Gaming.LocalMultiplayerAgent
     using Microsoft.AspNetCore.Mvc;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Converters;
+    using Microsoft.Azure.Gaming.VmAgent.Core;
+    using Microsoft.Azure.Gaming.VmAgent.Core.Interfaces;
+    using Microsoft.Azure.Gaming.VmAgent.Core.Dependencies;
 
     public class Startup
     {
@@ -36,10 +39,13 @@ namespace Microsoft.Azure.Gaming.LocalMultiplayerAgent
                     options.SerializerSettings.NullValueHandling = NullValueHandling.Ignore;
                     options.SerializerSettings.Converters.Add(new StringEnumConverter());
                 });
+            
+            BasicAssetExtractor.Instance = new BasicAssetExtractor(SystemOperations.Default, Globals.MultiLogger);
 
             services.AddLogging(builder => builder
                 .AddConsole()
                 .AddDebug());
+
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/LocalMultiplayerAgent/Startup.cs
+++ b/LocalMultiplayerAgent/Startup.cs
@@ -12,9 +12,6 @@ namespace Microsoft.Azure.Gaming.LocalMultiplayerAgent
     using Microsoft.AspNetCore.Mvc;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Converters;
-    using Microsoft.Azure.Gaming.VmAgent.Core;
-    using Microsoft.Azure.Gaming.VmAgent.Core.Interfaces;
-    using Microsoft.Azure.Gaming.VmAgent.Core.Dependencies;
 
     public class Startup
     {
@@ -39,13 +36,10 @@ namespace Microsoft.Azure.Gaming.LocalMultiplayerAgent
                     options.SerializerSettings.NullValueHandling = NullValueHandling.Ignore;
                     options.SerializerSettings.Converters.Add(new StringEnumConverter());
                 });
-            
-            BasicAssetExtractor.Instance = new BasicAssetExtractor(SystemOperations.Default, Globals.MultiLogger);
 
             services.AddLogging(builder => builder
                 .AddConsole()
                 .AddDebug());
-
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/VmAgent.Core.UnitTests/BasicAssetExtractorTest.cs
+++ b/VmAgent.Core.UnitTests/BasicAssetExtractorTest.cs
@@ -1,0 +1,134 @@
+﻿
+using FluentAssertions;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.Azure.Gaming.VmAgent;
+using Microsoft.Azure.Gaming.VmAgent.Core;
+using Microsoft.Azure.Gaming.VmAgent.Core.Dependencies;
+using Microsoft.Azure.Gaming.VmAgent.Core.Interfaces;
+using Microsoft.Azure.Gaming.VmAgent.Core.UnitTests;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VmAgent.Core.UnitTests
+{
+    [TestClass]
+    public class BasicAssetExtractorTest
+    {
+        private BasicAssetExtractor _basicAssetExtractor;
+
+        private MultiLogger _multiLogger;
+        private Mock<ISystemOperations> _mockSystemOperations;
+
+        private readonly string[] LinuxSupportedFileExtensions = 
+            { Constants.ZipExtension, Constants.TarExtension, Constants.TarGZipExtension };
+
+        private readonly string _TarAssetFileName = "testAsset.tar";
+        private readonly string _TarGzAssetFileName = "testAsset.tar.gz";
+        private readonly string _ZipAssetFileName = "testAsset.zip";
+        private readonly string _targetFolder = @"/data/targetPath";
+
+        [TestInitialize]
+        public void BeforeEachTest()
+        {
+            _multiLogger = new MultiLogger(NullLogger.Instance, new TelemetryClient(TelemetryConfiguration.CreateDefault()));
+            _mockSystemOperations = new Mock<ISystemOperations>();
+            _basicAssetExtractor = new BasicAssetExtractor(_mockSystemOperations.Object, _multiLogger);
+            
+            _mockSystemOperations.Setup(x => x.IsOSPlatform(OSPlatform.Windows)).Returns(false);
+        }
+
+
+        [TestMethod, TestCategory("BVT")]
+        public void AssetExtractionFailedOnLinux()
+        {
+            _mockSystemOperations.Setup(x => x.RunProcessWithStdCapture(It.IsAny<Process>())).Returns((1, "stdOut", "stdErr"));
+
+            ExceptionAssert.Throws<Exception>(() => _basicAssetExtractor.ExtractAssets(_TarAssetFileName, _targetFolder));
+        }
+
+        [TestMethod, TestCategory("BVT")]
+        public void VerifyProcessStartInfoForTar()
+        {
+            ProcessStartInfo testProcessInfo = 
+                _basicAssetExtractor.GetProcessStartInfoForTarOrGZip(_TarAssetFileName, _targetFolder);
+
+            ProcessStartInfo expectedProcessInfo = GetExpectedProcessInfoOnLinux(_TarAssetFileName, _targetFolder);
+
+            VerifyValidProcessStartInfo(testProcessInfo, expectedProcessInfo);
+        }
+
+        [TestMethod, TestCategory("BVT")]
+        public void VerifyProcessStartInfoForTarGZ()
+        {
+            ProcessStartInfo testProcessInfo =
+                _basicAssetExtractor.GetProcessStartInfoForTarOrGZip(_TarGzAssetFileName, _targetFolder);
+
+            ProcessStartInfo expectedProcessInfo = GetExpectedProcessInfoOnLinux(_TarGzAssetFileName, _targetFolder);
+
+            VerifyValidProcessStartInfo(testProcessInfo, expectedProcessInfo);
+        }
+
+        [TestMethod, TestCategory("BVT")]
+        public void VerifyProcessStartInfoForZipOnLinux()
+        {
+            ProcessStartInfo testProcessInfo =
+                _basicAssetExtractor.GetProcessStartInfoForZip(_ZipAssetFileName, _targetFolder);
+
+            ProcessStartInfo expectedProcessInfo = GetExpectedProcessInfoOnLinux(_ZipAssetFileName, _targetFolder);
+
+            VerifyValidProcessStartInfo(testProcessInfo, expectedProcessInfo);
+        }
+
+        public void VerifyValidProcessStartInfo(ProcessStartInfo testProcessInfo, ProcessStartInfo expectedProcessInfo)
+        {
+            Assert.AreEqual(expectedProcessInfo.FileName, testProcessInfo.FileName);
+            Assert.AreEqual(expectedProcessInfo.Arguments, testProcessInfo.Arguments);
+            Assert.AreEqual(expectedProcessInfo.UseShellExecute, testProcessInfo.UseShellExecute);
+            Assert.AreEqual(expectedProcessInfo.RedirectStandardError, testProcessInfo.RedirectStandardError);
+            Assert.AreEqual(expectedProcessInfo.RedirectStandardOutput, testProcessInfo.RedirectStandardOutput);
+            Assert.AreEqual(expectedProcessInfo.CreateNoWindow, testProcessInfo.CreateNoWindow);
+        }
+
+        public bool ValidateAssetFileName(string assetFileName)
+        {
+            return LinuxSupportedFileExtensions.Any(extension => assetFileName.EndsWith(extension, StringComparison.InvariantCultureIgnoreCase));
+        }
+
+        public ProcessStartInfo GetExpectedProcessInfoOnLinux(string assetFileName, string targetFolder)
+        {
+            Assert.IsTrue(ValidateAssetFileName(assetFileName));
+            
+            string fileExtension = Path.GetExtension(assetFileName).ToLowerInvariant();
+
+            string argumentForExtraction = "";
+
+            if (fileExtension == Constants.ZipExtension)
+            {
+                argumentForExtraction = $"-c \"unzip -oq {assetFileName} -d {targetFolder}\"";
+            } else {
+                string tarArguments = fileExtension == Constants.TarExtension ? "-xf" : "-xzf";
+                argumentForExtraction = $"-c \"tar {tarArguments} {assetFileName} -C {targetFolder} --strip-components 1\"";
+            }
+            
+            return new ProcessStartInfo()
+            {
+                FileName = "/bin/bash",
+                Arguments = argumentForExtraction,
+                UseShellExecute = false,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                CreateNoWindow = true
+            };
+        }
+    }
+}

--- a/VmAgent.Core.UnitTests/ExceptionAssert.cs
+++ b/VmAgent.Core.UnitTests/ExceptionAssert.cs
@@ -1,0 +1,36 @@
+﻿namespace Microsoft.Azure.Gaming.VmAgent.Core.UnitTests
+{
+    using System;
+    using System.Threading.Tasks;
+    using VisualStudio.TestTools.UnitTesting;
+
+    public class ExceptionAssert
+    {
+        public static T Throws<T>(Action testAction)
+            where T : Exception
+        {
+            Exception actualException = null;
+            try
+            {
+                testAction();
+            }
+            catch (Exception ex)
+            {
+                actualException = ex;
+            }
+
+            if (actualException == null)
+            {
+                Assert.Fail($"No exception was thrown. Expected exception - {typeof(T).FullName}");
+            }
+
+            Assert.AreEqual(
+                typeof(T).FullName,
+                actualException.GetType().FullName,
+                "Unexpected exception type: {0}",
+                actualException);
+
+            return (T)actualException;
+        }
+    }
+}

--- a/VmAgent.Core/Constants.cs
+++ b/VmAgent.Core/Constants.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Azure.Gaming.VmAgent
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Core;
+    using Core.Interfaces;
+
+    public static class Constants
+    {
+        public const string ZipExtension = ".zip";
+
+        public const string TarExtension = ".tar";
+
+        public const string TarGZipExtension = ".tar.gz";
+    }
+}

--- a/VmAgent.Core/Dependencies/BasicAssetExtractor.cs
+++ b/VmAgent.Core/Dependencies/BasicAssetExtractor.cs
@@ -1,14 +1,16 @@
-﻿using Microsoft.Azure.Gaming.VmAgent.Core.Interfaces;
+﻿using Microsoft.Azure.Gaming.VmAgent.Core.Dependencies.Interfaces;
+using Microsoft.Azure.Gaming.VmAgent.Core.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
+using VmAgent.Core.Interfaces;
 
 namespace Microsoft.Azure.Gaming.VmAgent.Core.Dependencies
 {
-    public class BasicAssetExtractor
+    public class BasicAssetExtractor: IBasicAssetExtractor
     {
         public static BasicAssetExtractor Instance = new BasicAssetExtractor();
 
@@ -68,7 +70,8 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Dependencies
             }
         }
 
-        private ProcessStartInfo GetProcessStartInfoForZip(string assetFileName, string targetFolder)
+
+        public ProcessStartInfo GetProcessStartInfoForZip(string assetFileName, string targetFolder)
         {
             return new ProcessStartInfo()
             {
@@ -83,7 +86,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Dependencies
             };
         }
 
-        private ProcessStartInfo GetProcessStartInfoForTarOrGZip(string assetFileName, string targetFolder)
+        public ProcessStartInfo GetProcessStartInfoForTarOrGZip(string assetFileName, string targetFolder)
         {
             // x - extract, z - decompress, f - filename (needs to be last argument)
             string tarArguments = Path.GetExtension(assetFileName).ToLowerInvariant() == Constants.TarExtension ? "-xf" : "-xzf";

--- a/VmAgent.Core/Dependencies/BasicAssetExtractor.cs
+++ b/VmAgent.Core/Dependencies/BasicAssetExtractor.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Dependencies
             }
             else
             {
+                // If the OS is Linux, we need to extract files using Linux Command Line.
                 if (!LinuxSupportedFileExtensions.Any(extension => assetFileName.EndsWith(extension, StringComparison.InvariantCultureIgnoreCase)))
                 {
                     throw new AssetExtractionFailedException($"Only Tar, Tar.gz and Zip formats are supported in Linux. Unable to extract {assetFileName}.");

--- a/VmAgent.Core/Dependencies/BasicAssetExtractor.cs
+++ b/VmAgent.Core/Dependencies/BasicAssetExtractor.cs
@@ -1,0 +1,109 @@
+﻿using Microsoft.Azure.Gaming.VmAgent.Core.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Microsoft.Azure.Gaming.VmAgent.Core.Dependencies
+{
+    public class BasicAssetExtractor
+    {
+        public static BasicAssetExtractor Instance = new BasicAssetExtractor();
+
+        private readonly ISystemOperations _systemOperations;
+        private readonly MultiLogger _logger;
+        private string _zipExtension;
+        private string _tarExtension;
+
+        public BasicAssetExtractor(ISystemOperations systemOperations = null, MultiLogger logger = null, string zipExtension = null, string tarExtension = null)
+        { 
+            _systemOperations = systemOperations;
+            _logger = logger;
+            _zipExtension = zipExtension;
+            _tarExtension = tarExtension;
+        }
+
+        public void ExtractAssets(string assetFileName, string targetFolder)
+        {
+            // If the OS is windows use the native .NET zip extraction (we only support .zip for Windows).
+            if (_systemOperations.IsOSPlatform(OSPlatform.Windows))
+            {
+                if (Directory.Exists(targetFolder))
+                {
+                    Directory.Delete(targetFolder, true);
+                }
+
+                _systemOperations.ExtractToDirectory(assetFileName, targetFolder);
+            }
+            else
+            {
+                _systemOperations.CreateDirectory(targetFolder);
+
+                ProcessStartInfo processStartInfo = Path.GetExtension(assetFileName).ToLowerInvariant() == _zipExtension
+                   ? GetProcessStartInfoForZip(assetFileName, targetFolder)
+                   : GetProcessStartInfoForTarOrGZip(assetFileName, targetFolder);
+
+                _logger.LogInformation($"Starting asset extraction with command arguments: {processStartInfo.Arguments}");
+
+                using (Process process = new Process())
+                {
+                    process.StartInfo = processStartInfo;
+                    (int exitCode, string stdOut, string stdErr) = _systemOperations.RunProcessWithStdCapture(process);
+
+                    if (!string.IsNullOrEmpty(stdOut))
+                    {
+                        _logger.LogVerbose(stdOut);
+                    }
+
+                    if (!string.IsNullOrEmpty(stdErr))
+                    {
+                        _logger.LogError(stdErr);
+                    }
+
+                    if (exitCode != 0)
+                    {
+                        throw new Exception($"Asset extraction for file {assetFileName} failed. Errors: {stdErr ?? string.Empty}");
+                    }
+
+                    _systemOperations.SetUnixOwnerIfNeeded(targetFolder, true);
+                }
+            }
+        }
+
+        private ProcessStartInfo GetProcessStartInfoForZip(string assetFileName, string targetFolder)
+        {
+            return new ProcessStartInfo()
+            {
+                FileName = "/bin/bash",
+
+                // o - overwrite, q - quiet, d - targetDirectory
+                Arguments = $"-c \"unzip -oq {assetFileName} -d {targetFolder}\"",
+                UseShellExecute = false,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                CreateNoWindow = true
+            };
+        }
+
+        private ProcessStartInfo GetProcessStartInfoForTarOrGZip(string assetFileName, string targetFolder)
+        {
+            // x - extract, z - decompress, f - filename (needs to be last argument)
+            string tarArguments = Path.GetExtension(assetFileName).ToLowerInvariant() == _tarExtension ? "-xf" : "-xzf";
+            return new ProcessStartInfo()
+            {
+                FileName = "/bin/bash",
+
+                // Tar extraction by default creates a new top level directory. Strip component allows to override that
+                // and extract files directly in to the targetFolder.
+                Arguments = $"-c \"tar {tarArguments} {assetFileName} -C {targetFolder} --strip-components 1\"",
+                UseShellExecute = false,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                CreateNoWindow = true
+            };
+        }
+
+    }
+}

--- a/VmAgent.Core/Dependencies/BasicAssetExtractor.cs
+++ b/VmAgent.Core/Dependencies/BasicAssetExtractor.cs
@@ -14,15 +14,11 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Dependencies
 
         private readonly ISystemOperations _systemOperations;
         private readonly MultiLogger _logger;
-        private string _zipExtension;
-        private string _tarExtension;
 
-        public BasicAssetExtractor(ISystemOperations systemOperations = null, MultiLogger logger = null, string zipExtension = null, string tarExtension = null)
+        public BasicAssetExtractor(ISystemOperations systemOperations = null, MultiLogger logger = null)
         { 
             _systemOperations = systemOperations;
             _logger = logger;
-            _zipExtension = zipExtension;
-            _tarExtension = tarExtension;
         }
 
         public void ExtractAssets(string assetFileName, string targetFolder)
@@ -41,7 +37,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Dependencies
             {
                 _systemOperations.CreateDirectory(targetFolder);
 
-                ProcessStartInfo processStartInfo = Path.GetExtension(assetFileName).ToLowerInvariant() == _zipExtension
+                ProcessStartInfo processStartInfo = Path.GetExtension(assetFileName).ToLowerInvariant() == Constants.ZipExtension
                    ? GetProcessStartInfoForZip(assetFileName, targetFolder)
                    : GetProcessStartInfoForTarOrGZip(assetFileName, targetFolder);
 
@@ -90,7 +86,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Dependencies
         private ProcessStartInfo GetProcessStartInfoForTarOrGZip(string assetFileName, string targetFolder)
         {
             // x - extract, z - decompress, f - filename (needs to be last argument)
-            string tarArguments = Path.GetExtension(assetFileName).ToLowerInvariant() == _tarExtension ? "-xf" : "-xzf";
+            string tarArguments = Path.GetExtension(assetFileName).ToLowerInvariant() == Constants.TarExtension ? "-xf" : "-xzf";
             return new ProcessStartInfo()
             {
                 FileName = "/bin/bash",

--- a/VmAgent.Core/Dependencies/Interfaces/Exceptions/AssetExtractionFailedException.cs
+++ b/VmAgent.Core/Dependencies/Interfaces/Exceptions/AssetExtractionFailedException.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace VmAgent.Core.Dependencies.Interfaces.Exceptions
+{
+    [Serializable]
+    public class AssetExtractionFailedException : Exception
+    {
+        public AssetExtractionFailedException(string message) : base(message)
+        {
+          
+        }
+
+        protected AssetExtractionFailedException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+           
+        }
+
+    }
+}

--- a/VmAgent.Core/Dependencies/Interfaces/IBasicAssetExtractor.cs
+++ b/VmAgent.Core/Dependencies/Interfaces/IBasicAssetExtractor.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+
+namespace Microsoft.Azure.Gaming.VmAgent.Core.Dependencies.Interfaces
+{
+    public interface IBasicAssetExtractor
+    {
+        void ExtractAssets(string assetFileName, string targetFolder);
+
+        ProcessStartInfo GetProcessStartInfoForZip(string assetFileName, string targetFolder);
+
+        ProcessStartInfo GetProcessStartInfoForTarOrGZip(string assetFileName, string targetFolder);
+    }
+}


### PR DESCRIPTION
To support running Linux Process on Linux in LocalMultiplayerAgent
1) deleted OS validation code in MultiplayerSettingsValidator.cs.
2) added file extension variables in Globals.cs - these variables are also defined in VmAgent
3) added GetProcessStartInfoForZip() and GetProcessStartInfoForTarOrGZip to support zip and tar/targ on Linux (defined in VmAgent)