### PR TITLE
Added support for process-based crash dumps in VmAgent.

### DIFF
--- a/LocalMultiplayerAgent/MultiplayerServerManager.cs
+++ b/LocalMultiplayerAgent/MultiplayerServerManager.cs
@@ -74,14 +74,19 @@ namespace Microsoft.Azure.Gaming.LocalMultiplayerAgent
             NoOpSessionHostManager sessionHostManager = new NoOpSessionHostManager();
             SessionHostInfo sessionHostInfo =
                 await sessionHostRunner.CreateAndStart(0, new GameResourceDetails { SessionHostsStartInfo = startParameters }, sessionHostManager);
-            string containerId = sessionHostInfo.TypeSpecificId;
+            if (sessionHostInfo == null)
+            {
+                return;
+            }
+
+            string typeSpecificId = sessionHostInfo.TypeSpecificId;
             
             _logger.LogInformation("Waiting for heartbeats from the game server.....");
 
-            await sessionHostRunner.WaitOnServerExit(containerId).ConfigureAwait(false);
+            await sessionHostRunner.WaitOnServerExit(typeSpecificId).ConfigureAwait(false);
             string logFolder = Path.Combine(Globals.VmConfiguration.VmDirectories.GameLogsRootFolderVm, sessionHostInfo.LogFolderId);
-            await sessionHostRunner.CollectLogs(containerId, logFolder, sessionHostManager);
-            await sessionHostRunner.TryDelete(containerId);
+            await sessionHostRunner.CollectLogs(typeSpecificId, logFolder, Globals.VmConfiguration.VmDirectories.DumpsRootFolderVm, sessionHostManager);
+            await sessionHostRunner.TryDelete(typeSpecificId);
         }
 
         private void DownloadAndExtractAllAssets(SessionHostsStartInfo gameResourceDetails)

--- a/VmAgent.Core/Interfaces/BaseSessionHostRunner.cs
+++ b/VmAgent.Core/Interfaces/BaseSessionHostRunner.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.ContainerEngines
             _systemOperations = systemOperations;
         }
 
-        abstract public Task CollectLogs(string id, string logsFolder, ISessionHostManager sessionHostManager);
+        abstract public Task CollectLogs(string id, string logsFolder, string dumpsFolderVm, ISessionHostManager sessionHostManager);
 
         abstract public Task<SessionHostInfo> CreateAndStart(int instanceNumber, GameResourceDetails gameResourceDetails, ISessionHostManager sessionHostManager);
 

--- a/VmAgent.Core/Interfaces/ISessionHostRunner.cs
+++ b/VmAgent.Core/Interfaces/ISessionHostRunner.cs
@@ -24,6 +24,6 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
 
         Task WaitOnServerExit(string containerId);
 
-        Task CollectLogs(string id, string logsFolder, ISessionHostManager sessionHostManager);
+        Task CollectLogs(string id, string logsFolder, string dumpsFolderVm, ISessionHostManager sessionHostManager);
     }
 }

--- a/VmAgent.Core/VmAgent.Core.csproj
+++ b/VmAgent.Core/VmAgent.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>1.5.3</PackageVersion>
+    <PackageVersion>1.5.4</PackageVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageDescription>Helper library for LocalMultiplayerAgent, part of Azure PlayFab Multiplayer Servers</PackageDescription>
     <PackageProjectUrl>https://github.com/PlayFab/MpsAgent</PackageProjectUrl>

--- a/VmAgent.Core/VmDirectories.cs
+++ b/VmAgent.Core/VmDirectories.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core
 
             GameSharedContentFolderVm = Path.Combine(TempStorageRootVm, "GameSharedContent");
             GameLogsRootFolderVm = Path.Combine(TempStorageRootVm, "GameLogs");
+            DumpsRootFolderVm = Path.Combine(TempStorageRootVm, "Dumps");
             AssetExtractionRootFolderVm = Path.Combine(TempStorageRootVm, "ExtAssets");
             AssetDownloadRootFolderVm = Path.Combine(TempStorageRootVm, "DownloadedAssets");
             CertificateRootFolderVm = Path.Combine(TempStorageRootVm, "GameCertificates");
@@ -59,6 +60,10 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core
         public string GameSharedContentFolderContainer { get; set; }
 
         public string GameLogsRootFolderVm { get; }
+
+        // Only used on Process-based servers. All dumps are placed in this folder, and then must be moved into
+        // the corresponding server's logs/_dumps folder during log upload.
+        public string DumpsRootFolderVm { get; }
 
         public string GameLogsRootFolderContainer { get; set; }
 


### PR DESCRIPTION
If crash dumps are enabled for process based servers, all crash dumps will be placed in a shared root folder on the VM. The dumps have the processId in the filename, so during log upload VmAgent checks that folder for a dump from the current server's process and moves it into the logs folder.
This functionality won't work in LocalMultiplayerAgent, however.