### PR TITLE
Test to ensure enum order doesn't change when a new VmState is added

### DIFF
--- a/AgentInterfaces.Tests/VmAgentInfoTests.cs
+++ b/AgentInterfaces.Tests/VmAgentInfoTests.cs
@@ -64,27 +64,30 @@ namespace AgentInterfaces.Tests
         /// </summary>
         [TestMethod]
         [TestCategory("BVT")]
-        public void VmStateEnumOrder()
+        public void KnowVmStateOrder()
         {
-            var vmStatesEnumIntCast = new Dictionary<VmState, int>
+           //we need to keep the order vm state because we use this order to determine healthy vms to release
+            var knownVmStateOrder = new Dictionary<string, int>
             {
-                {VmState.Unknown, 0},
-                {VmState.Unassigned, 1},
-                {VmState.Assigned, 2},
-                {VmState.Propping, 3},
-                {VmState.ProppingFailed, 4},
-                {VmState.ProppingCompleted, 5},
-                {VmState.ServerStartFailed, 6},
-                {VmState.StartServersFailed, 7},
-                {VmState.PartiallyRunning, 8},
-                {VmState.Running, 9},
-                {VmState.PendingResourceCleanup, 10},
-                {VmState.ServersRemoved, 12},
-                {VmState.TooManyServerRestarts, 13}
+                {nameof(VmState.Unknown), 0},
+                {nameof(VmState.Unassigned), 1},
+                {nameof(VmState.Assigned), 2 },
+                {nameof(VmState.Propping), 3 },
+                {nameof(VmState.ProppingFailed), 4},
+                {nameof(VmState.ProppingCompleted), 5},
+                {"ServerStartFailed", 6}, //obselete vmstate
+                {nameof(VmState.StartServersFailed), 7},
+                {"PartiallyRunning", 8}, //obselete vmstate
+                {nameof(VmState.Running), 9},
+                {nameof(VmState.PendingResourceCleanup), 10},
+                {"SessionHostsRemoved", 11 }, //obselete vmstate
+                {nameof(VmState.ServersRemoved), 12},
+                {nameof(VmState.TooManyServerRestarts), 13 }
             };
-            foreach (VmState vmState in vmStatesEnumIntCast.Keys)
+           
+            foreach(string vmstate in knownVmStateOrder.Keys)
             {
-                Assert.AreEqual((int)vmState, vmStatesEnumIntCast[vmState]);
+                Assert.IsFalse((int)Enum.Parse(typeof(VmState), vmstate) != knownVmStateOrder[vmstate], $"Please keep VmState $vmstate in original order and add new VmState in the end.");
             }
         }
     }

--- a/AgentInterfaces.Tests/VmAgentInfoTests.cs
+++ b/AgentInterfaces.Tests/VmAgentInfoTests.cs
@@ -59,20 +59,24 @@ namespace AgentInterfaces.Tests
             Assert.IsFalse(newProperties.Any(), $"Please add new properties {string.Join(", ", newProperties)} to the list above and to the ToLogString method.");
         }
 
+        /// <summary>
+        /// Test to ensure enum order doesn't change when a new VmState is added. Control plane relies on this enum to determine the order healthyVmsEligibleToRelease.
+        /// </summary>
         [TestMethod]
         [TestCategory("BVT")]
-        public void TestVmStateEnumIntCast()
+        public void VmStateEnumOrder()
         {
             var vmStatesEnumIntCast = new Dictionary<VmState, int>
             {
-                //test all vm states except for obsolete ones
                 {VmState.Unknown, 0},
                 {VmState.Unassigned, 1},
                 {VmState.Assigned, 2},
                 {VmState.Propping, 3},
                 {VmState.ProppingFailed, 4},
                 {VmState.ProppingCompleted, 5},
+                {VmState.ServerStartFailed, 6},
                 {VmState.StartServersFailed, 7},
+                {VmState.PartiallyRunning, 8},
                 {VmState.Running, 9},
                 {VmState.PendingResourceCleanup, 10},
                 {VmState.ServersRemoved, 12},

--- a/AgentInterfaces.Tests/VmAgentInfoTests.cs
+++ b/AgentInterfaces.Tests/VmAgentInfoTests.cs
@@ -58,5 +58,30 @@ namespace AgentInterfaces.Tests
             IReadOnlyList<string> newProperties = propertyNames.Except(knownProperties).ToList();
             Assert.IsFalse(newProperties.Any(), $"Please add new properties {string.Join(", ", newProperties)} to the list above and to the ToLogString method.");
         }
+
+        [TestMethod]
+        [TestCategory("BVT")]
+        public void TestVmStateEnumIntCast()
+        {
+            var vmStatesEnumIntCast = new Dictionary<VmState, int>
+            {
+                //test all vm states except for obsolete ones
+                {VmState.Unknown, 0},
+                {VmState.Unassigned, 1},
+                {VmState.Assigned, 2},
+                {VmState.Propping, 3},
+                {VmState.ProppingFailed, 4},
+                {VmState.ProppingCompleted, 5},
+                {VmState.StartServersFailed, 7},
+                {VmState.Running, 9},
+                {VmState.PendingResourceCleanup, 10},
+                {VmState.ServersRemoved, 12},
+                {VmState.TooManyServerRestarts, 13}
+            };
+            foreach (VmState vmState in vmStatesEnumIntCast.Keys)
+            {
+                Assert.AreEqual((int)vmState, vmStatesEnumIntCast[vmState]);
+            }
+        }
     }
 }


### PR DESCRIPTION
this is to add a test for the comment in this PR: https://dev.azure.com/playfab/PlayFab/_git/Thunderhead/pullrequest/11451
"Although unlikely to happen, it might be worth adding a test to ensure the order of enums does not change. In general, new enum values are added at the bottom of the list. Sometimes, people do miss that and add it in between which could then break this assumption"

we rely on this enum to determine the order healthyVmsEligibleToRelease . This test is added to ensure enum order doesn't change. 