### PR TITLE
Add maintenance event data to persisted state.

### DIFF
--- a/LocalMultiplayerAgent/NoOpSessionHostManager.cs
+++ b/LocalMultiplayerAgent/NoOpSessionHostManager.cs
@@ -172,5 +172,14 @@ namespace Microsoft.Azure.Gaming.LocalMultiplayerAgent
         {
             return "";
         }
+
+        public void MarkForMaintenance(MaintenanceSchedule schedule)
+        {
+        }
+
+        public bool IsMarkedForMaintenance()
+        {
+            return false;
+        }
     }
 }

--- a/VmAgent.Core/Interfaces/ISessionHostManager.cs
+++ b/VmAgent.Core/Interfaces/ISessionHostManager.cs
@@ -78,5 +78,9 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
         string GetLogFolderForSessionHostId(string sessionHostId);
 
         string GetTypeSpecificIdForSessionHost(string sessionHostId);
+
+        void MarkForMaintenance(MaintenanceSchedule schedule);
+
+        bool IsMarkedForMaintenance();
     }
 }

--- a/VmAgent.Core/Model/VmPersistedState.cs
+++ b/VmAgent.Core/Model/VmPersistedState.cs
@@ -20,6 +20,11 @@ namespace Microsoft.Azure.Gaming.VmAgent.Model
         public SessionHostsStartInfo GameResourceDetails { get; set; }
 
         /// <summary>
+        /// Maintenance schedule for this VM, if any.
+        /// </summary>
+        public MaintenanceSchedule MaintenanceSchedule { get; set; }
+
+        /// <summary>
         /// Whether the start up script (at VM) level has been executed. The script should be run before starting session hosts.
         /// </summary>
         public bool IsSessionHostStartupScriptExecutionComplete { get; set; }

--- a/VmAgent.Core/VmAgent.Core.csproj
+++ b/VmAgent.Core/VmAgent.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>1.6.1</PackageVersion>
+    <PackageVersion>1.6.2</PackageVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageDescription>Helper library for LocalMultiplayerAgent, part of Azure PlayFab Multiplayer Servers</PackageDescription>
     <PackageProjectUrl>https://github.com/PlayFab/MpsAgent</PackageProjectUrl>


### PR DESCRIPTION
The goal is to not start new servers (after previous ones exit), if the VM is marked for maintenance, to avoid minimum disruption to games. Note that, the MPS control plane already takes care of not allocating on VMs that are marked for maintenance. This is mostly for games that use external allocation and do not do it via MPS Allocation Apis.

Essentially, the way this works would be:
1) VmAgent, on seeing a maintenance event, calls the game's OnMaintenanceEvent callback. The game, if not Active, exits.
2) VmAgent doesn't bring up new servers in its place. This ensures that new servers do not come up and report to the customer's Matchmaking/ControlPlane and end up being used for an allocation.

Note that, we persist the information for 2 reasons:
1) To make sure VM crashes and other issues do not lose this info.
2) We want to mark a VM that has ever been in a maintenance event. The reason being, that the MPS control plane, as soon as it sees a VM is scheduled for maintenance, stops using it for allocation and attempts to release it. If there are active game servers, this will be delayed, but eventually, the VM will get deleted. This can happen AFTER the maintenance event completes. At that time, we do not want the VMAgent to start servers, just before being deleted. It is possible that this can be solved just by keeping it in memory but it does introduce a few race conditions. Persisting it is a safer bet.