### PR TITLE
extending heartbeat response

### DIFF
--- a/AgentInterfaces/MaintenanceSchedule.cs
+++ b/AgentInterfaces/MaintenanceSchedule.cs
@@ -19,10 +19,6 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
 
         public string ReportingVmId { get; set; }
 
-        /// <summary>
-        /// The source of the maintenance event. It can be either Azure or PlayFab
-        /// </summary>
-        public string MaintenanceSource { get; set; }
     }
 
     // https://docs.microsoft.com/en-us/azure/virtual-machines/windows/scheduled-events#query-for-events

--- a/AgentInterfaces/MaintenanceSchedule.cs
+++ b/AgentInterfaces/MaintenanceSchedule.cs
@@ -8,12 +8,6 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
     using Newtonsoft.Json;
     using Newtonsoft.Json.Converters;
 
-    [Serializable]
-    public class MaintenanceScheduleEx : MaintenanceSchedule
-    {
-        public MaintenanceReason MaintenanceReason { get; set; }
-    }
-
     // Data Format: https://docs.microsoft.com/en-us/azure/virtual-machines/windows/scheduled-events
     [Serializable]
     public class MaintenanceSchedule
@@ -24,6 +18,11 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
         public IList<MaintenanceEvent> MaintenanceEvents { get; set; }
 
         public string ReportingVmId { get; set; }
+
+        /// <summary>
+        /// The source of the maintenance event. It can be either Azure or PlayFab
+        /// </summary>
+        public string MaintenanceSource { get; set; }
     }
 
     // https://docs.microsoft.com/en-us/azure/virtual-machines/windows/scheduled-events#query-for-events
@@ -46,12 +45,5 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
         public string EventSource { get; set; }
 
         public int DurationInSeconds { get; set; }
-    }
-
-    [JsonConverter(typeof(StringEnumConverter))]
-    public enum MaintenanceReason
-    {
-        Azure,
-        PlayFab
     }
 }

--- a/AgentInterfaces/MaintenanceSchedule.cs
+++ b/AgentInterfaces/MaintenanceSchedule.cs
@@ -6,8 +6,16 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
     using System;
     using System.Collections.Generic;
     using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
 
-    // Data Format: https://docs.microsoft.com/en-us/azure/virtual-machines/virtual-machines-scheduled-events
+    [Serializable]
+    public class MaintenanceScheduleEx : MaintenanceSchedule
+    {
+        public MaintenanceReason MaintenanceReason { get; set; }
+    }
+
+    // Data Format: https://docs.microsoft.com/en-us/azure/virtual-machines/windows/scheduled-events
+    [Serializable]
     public class MaintenanceSchedule
     {
         public string DocumentIncarnation { get; set; }
@@ -19,6 +27,7 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
     }
 
     // https://docs.microsoft.com/en-us/azure/virtual-machines/windows/scheduled-events#query-for-events
+    [Serializable]
     public class MaintenanceEvent
     {
         public string EventId { get; set; }
@@ -37,5 +46,12 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
         public string EventSource { get; set; }
 
         public int DurationInSeconds { get; set; }
+    }
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum MaintenanceReason
+    {
+        Azure,
+        PlayFab
     }
 }

--- a/AgentInterfaces/SessionHostHeartbeatInfo.cs
+++ b/AgentInterfaces/SessionHostHeartbeatInfo.cs
@@ -60,9 +60,9 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
         public DateTime? NextScheduledMaintenanceUtc { get; set; }
 
         /// <summary>
-        /// Schedule of the next planned maintenance
+        /// Planned maintenance events
         /// </summary>
-        public MaintenanceSchedule NextScheduledMaintenance { get; set; }
+        public MaintenanceSchedule MaintenanceSchedule { get; set; }
 
         /// <summary>
         /// Used by some legacy games such as Forza 5 for security handshake with the game client.

--- a/AgentInterfaces/SessionHostHeartbeatInfo.cs
+++ b/AgentInterfaces/SessionHostHeartbeatInfo.cs
@@ -60,6 +60,11 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
         public DateTime? NextScheduledMaintenanceUtc { get; set; }
 
         /// <summary>
+        /// Schedule of the next planned maintenance
+        /// </summary>
+        public MaintenanceSchedule NextScheduledMaintenance { get; set; }
+
+        /// <summary>
         /// Used by some legacy games such as Forza 5 for security handshake with the game client.
         /// </summary>
         public string SecureDeviceAddress { get; set; }

--- a/AgentInterfaces/VmAgentSettings.cs
+++ b/AgentInterfaces/VmAgentSettings.cs
@@ -22,6 +22,12 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
         public HashSet<string> TitlesUsingExternalAllocations { get; set; }
 
         /// <summary>
+        /// Titles that are using MaintenanceV2 - essentially, getting the full maintenance schedule details on the
+        /// GSDK maintenance callback
+        /// </summary>
+        public HashSet<string> TitlesUsingMaintenanceV2 { get; set; } 
+
+        /// <summary>
         ///  Whether the maintenance schedule time should be passed to GSDK.
         /// </summary>
         public bool ShouldPassMaintenanceInfoToGsdk { get; set; }


### PR DESCRIPTION
Extending heartbeat response object to include:
- full details of potential planned maintenance
- source of the maintenance event
- setting for titles that we enable this feature for