### PR TITLE
new VmAgentSetting: ShutdownRequestedNotBefore

### DIFF
--- a/AgentInterfaces/MaintenanceSchedule.cs
+++ b/AgentInterfaces/MaintenanceSchedule.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using Newtonsoft.Json;
 
     // Data Format: https://docs.microsoft.com/en-us/azure/virtual-machines/virtual-machines-scheduled-events
@@ -16,6 +17,18 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
         public IList<MaintenanceEvent> MaintenanceEvents { get; set; }
 
         public string ReportingVmId { get; set; }
+
+        public MaintenanceSchedule() { }
+
+        /// <summary>
+        /// Deep copy used for testing
+        /// </summary>
+        public MaintenanceSchedule(MaintenanceSchedule other)
+        {
+            DocumentIncarnation = other.DocumentIncarnation;
+            MaintenanceEvents = other.MaintenanceEvents.Select((e) => new MaintenanceEvent(e)).ToList();
+            ReportingVmId = other.ReportingVmId;
+        }
     }
 
     // https://docs.microsoft.com/en-us/azure/virtual-machines/windows/scheduled-events#query-for-events
@@ -37,5 +50,22 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
         public string EventSource { get; set; }
 
         public int DurationInSeconds { get; set; }
+
+        public MaintenanceEvent() { }
+
+        /// <summary>
+        /// Deep copy used for testing
+        /// </summary>
+        public MaintenanceEvent(MaintenanceEvent other)
+        {
+            EventId = other.EventId;
+            EventType = other.EventType;
+            ResourceType = other.ResourceType;
+            AffectedResources = other.AffectedResources.ToList();
+            EventStatus = other.EventStatus;
+            NotBefore = other.NotBefore;
+            EventSource = other.EventSource;
+            DurationInSeconds = other.DurationInSeconds;
+        }
     }
 }

--- a/AgentInterfaces/VmAgentSettings.cs
+++ b/AgentInterfaces/VmAgentSettings.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.Azure.Gaming.AgentInterfaces
 {
+    using System;
     using System.Collections.Generic;
 
     public class VmAgentSettings
@@ -35,5 +36,12 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
         /// Whether we should stop bringing up new session hosts (when old ones terminate), if the VM has been scheduled for maintenance.
         /// </summary>
         public bool DisableSessionHostCreationOnMaintenanceEvent { get; set; }
+
+        /// <summary>
+        /// ControlPlane can use this field to notify VmAgent that it will shut down soon.
+        /// This isn't really a "setting", and isn't stored in Thunderfig. VmAgentSettings is just a convenient way for 
+        /// ControlPlane to communicate with VmAgent.
+        /// </summary>
+        public DateTimeOffset? ShutdownRequestedNotBefore { get; set; }
     }
 }


### PR DESCRIPTION
The `ShutdownRequestedNotBefore` field will be used by ControlPlane to notify VmAgent that it's nearing the end of its 10 day lifetime.
Also, added copy constructors to MaintenanceSchedule and MaintenanceEvent, which are used in VmAgent's unit tests for this feature.