### PR TITLE
added GetEnvironmentVariablesForVmScripts

### DIFF
--- a/VmAgent.Core.UnitTests/VmConfigurationTests.cs
+++ b/VmAgent.Core.UnitTests/VmConfigurationTests.cs
@@ -29,7 +29,7 @@ namespace VmAgent.Core.UnitTests
             var metadata = new Dictionary<string, string>() {{"key1", "value1"}, {"key2", "value2"}};
             SessionHostsStartInfo sessionHostsStartInfo = CreateSessionHostStartInfo(metadata);
             IDictionary<string, string> envVariables = VmConfiguration.GetCommonEnvironmentVariables(sessionHostsStartInfo, VmConfiguration);
-            ValidateEnvironmentVariables(envVariables, sessionHostsStartInfo);
+            ValidateCommonEnvironmentVariables(envVariables, sessionHostsStartInfo);
         }
 
         [TestMethod]
@@ -38,7 +38,17 @@ namespace VmAgent.Core.UnitTests
         {
             SessionHostsStartInfo sessionHostsStartInfo = CreateSessionHostStartInfo();
             IDictionary<string, string> envVariables = VmConfiguration.GetCommonEnvironmentVariables(sessionHostsStartInfo, VmConfiguration);
-            ValidateEnvironmentVariables(envVariables, sessionHostsStartInfo);
+            ValidateCommonEnvironmentVariables(envVariables, sessionHostsStartInfo);
+        }
+
+        [TestMethod]
+        [TestCategory("BVT")]
+        public void VmScriptEnvVariablesWithBuildMetadata()
+        {
+            var metadata = new Dictionary<string, string>() { { "key1", "value1" }, { "key2", "value2" } };
+            SessionHostsStartInfo sessionHostsStartInfo = CreateSessionHostStartInfo(metadata);
+            IDictionary<string, string> envVariables = VmConfiguration.GetEnvironmentVariablesForVmScripts(sessionHostsStartInfo, VmConfiguration);
+            ValidateVmScriptEnvironmentVariables(envVariables, sessionHostsStartInfo);
         }
 
         private SessionHostsStartInfo CreateSessionHostStartInfo(IDictionary<string, string> buildMetadata = null)
@@ -49,7 +59,7 @@ namespace VmAgent.Core.UnitTests
             };
         }
 
-        private void ValidateEnvironmentVariables(IDictionary<string, string> envVariables, SessionHostsStartInfo sessionHostsStartInfo)
+        private void ValidateCommonEnvironmentVariables(IDictionary<string, string> envVariables, SessionHostsStartInfo sessionHostsStartInfo)
         {
             envVariables.Should().Contain(VmConfiguration.PublicIPv4AddressEnvVariable, sessionHostsStartInfo.PublicIpV4Address);
             envVariables.Should().Contain(VmConfiguration.PublicIPv4AddressEnvVariableV2, sessionHostsStartInfo.PublicIpV4Address);
@@ -58,6 +68,12 @@ namespace VmAgent.Core.UnitTests
             envVariables.Should().Contain(VmConfiguration.BuildIdEnvVariable, DeploymentId.ToString());
             envVariables.Should().Contain(VmConfiguration.RegionEnvVariable, Region);
             sessionHostsStartInfo.DeploymentMetadata?.ForEach(x => envVariables.Should().Contain(x.Key, x.Value));
+        }
+
+        private void ValidateVmScriptEnvironmentVariables(IDictionary<string, string> envVariables, SessionHostsStartInfo sessionHostsStartInfo)
+        {
+            ValidateCommonEnvironmentVariables(envVariables, sessionHostsStartInfo);
+            envVariables.Should().Contain(VmConfiguration.SharedContentFolderVmVariable, VmConfiguration.VmDirectories.GameSharedContentFolderVm);
         }
 
         private string CreateAssignmentId()

--- a/VmAgent.Core.UnitTests/VmConfigurationTests.cs
+++ b/VmAgent.Core.UnitTests/VmConfigurationTests.cs
@@ -43,11 +43,11 @@ namespace VmAgent.Core.UnitTests
 
         [TestMethod]
         [TestCategory("BVT")]
-        public void VmScriptEnvVariablesWithBuildMetadata()
+        public void VmStartupScriptEnvVariablesWithBuildMetadata()
         {
             var metadata = new Dictionary<string, string>() { { "key1", "value1" }, { "key2", "value2" } };
             SessionHostsStartInfo sessionHostsStartInfo = CreateSessionHostStartInfo(metadata);
-            IDictionary<string, string> envVariables = VmConfiguration.GetEnvironmentVariablesForVmScripts(sessionHostsStartInfo, VmConfiguration);
+            IDictionary<string, string> envVariables = VmConfiguration.GetEnvironmentVariablesForVmStartupScripts(sessionHostsStartInfo, VmConfiguration);
             ValidateVmScriptEnvironmentVariables(envVariables, sessionHostsStartInfo);
         }
 

--- a/VmAgent.Core/VmConfiguration.cs
+++ b/VmAgent.Core/VmConfiguration.cs
@@ -104,13 +104,13 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core
         }
 
         /// <summary>
-        /// Gets the set of environment variables for scripts running at the VM level.
+        /// Gets the set of environment variables for startup scripts running at the VM level.
         /// </summary>
         /// <param name="sessionHostsStartInfo">The details for starting the game servers.</param>
         /// <param name="vmConfiguration">The details for the VM.</param>
         /// <returns>A dictionary of environment variables</returns>
         /// <remarks>This method is expected to be called only after the VM is assigned (i.e sessionHostsStartInfo is not null).</remarks>
-        public static IDictionary<string, string> GetEnvironmentVariablesForVmScripts(SessionHostsStartInfo sessionHostsStartInfo, VmConfiguration vmConfiguration)
+        public static IDictionary<string, string> GetEnvironmentVariablesForVmStartupScripts(SessionHostsStartInfo sessionHostsStartInfo, VmConfiguration vmConfiguration)
         {
             ArgumentValidator.ThrowIfNull(sessionHostsStartInfo, nameof(sessionHostsStartInfo));
             


### PR DESCRIPTION
Currently, game servers have a PF_SHARED_CONTENT_FOLDER environment variable that points them to a folder shared among all servers on a VM. For process based servers that points to the actual folder, and for container based servers it points to where that folder is mounted in the container.
When running a VM startup script, however, that environment variable isn't set. This PR creates a new environment variable, PF_SHARED_CONTENT_FOLDER_VM that points to where the shared content folder is on the VM. The Watson team needs this for their startup script.
I put that new environment variable inside `GetEnvironmentVariablesForVmScripts` because it doesn't belong in the "common" environment variables (which end up inside container-based servers). There will be a separate VmAgent PR to make the startup script use these variables when it runs a startup script.