### PR TITLE
changed ShutdownRequestedNotBefore to a DateTime

### DIFF
--- a/AgentInterfaces/VmAgentSettings.cs
+++ b/AgentInterfaces/VmAgentSettings.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
         /// This isn't really a "setting", and isn't stored in Thunderfig. VmAgentSettings is just a convenient way for 
         /// ControlPlane to communicate with VmAgent.
         /// </summary>
-        public DateTimeOffset? ShutdownRequestedNotBefore { get; set; }
+        public DateTime? ShutdownRequestedNotBeforeUtc { get; set; }
 
         /// <summary>
         /// List of disallowed executables.


### PR DESCRIPTION
I believe the breaking change is fine in the response contract. Since the existing field is nullable, VmAgent won't complain if it's missing. And VmAgent should just ignore the new field until it knows what to do with it