### PR TITLE
adding invalid state transition test + unit test

### DIFF
--- a/LocalMultiplayerAgent.UnitTest/ControllerTests.cs
+++ b/LocalMultiplayerAgent.UnitTest/ControllerTests.cs
@@ -3,29 +3,20 @@
 
 namespace Microsoft.Azure.Gaming.VmAgent.UnitTests
 {
-    using System;
-    using System.Configuration;
-    using System.IO;
     using System.Net.Http;
-    using System.Reflection;
     using System.Text;
     using System.Threading.Tasks;
     using AgentInterfaces;
-    using Core.Interfaces;
-    using FluentAssertions;
-    using LocalMultiplayerAgent.Config;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.TestHost;
     using Microsoft.Azure.Gaming.LocalMultiplayerAgent;
-    using Moq;
     using Newtonsoft.Json;
-    using Newtonsoft.Json.Linq;
     using VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
     public class ControllerTests
     {
-
+        private static readonly string jsonMediaType = "application/json";
         private TestServer server;
         protected HttpClient Client { get; private set; }
 
@@ -44,16 +35,16 @@ namespace Microsoft.Azure.Gaming.VmAgent.UnitTests
             {
                 CurrentGameState = SessionHostStatus.StandingBy
             };
-            var json = JsonConvert.SerializeObject(heartbeat);
-            var data = new StringContent(json, Encoding.UTF8, "application/json");
-            var value = await this.Client.PostAsync($"v1/sessionHosts/{sessionHostId}/heartbeats", data);
+            string json = JsonConvert.SerializeObject(heartbeat);
+            StringContent data = new StringContent(json, Encoding.UTF8, jsonMediaType);
+            HttpResponseMessage value = await this.Client.PostAsync($"v1/sessionHosts/{sessionHostId}/heartbeats", data);
 
             Assert.IsTrue(value.IsSuccessStatusCode);
 
-            // send the first heartbeat with "StandingBy"
+            // send the second heartbeat with "Initializing"
             heartbeat.CurrentGameState = SessionHostStatus.Initializing;
             json = JsonConvert.SerializeObject(heartbeat);
-            data = new StringContent(json, Encoding.UTF8, "application/json");
+            data = new StringContent(json, Encoding.UTF8, jsonMediaType);
             
             value = await this.Client.PostAsync($"v1/sessionHosts/{sessionHostId}/heartbeats", data);
             Assert.IsFalse(value.IsSuccessStatusCode);

--- a/LocalMultiplayerAgent.UnitTest/ControllerTests.cs
+++ b/LocalMultiplayerAgent.UnitTest/ControllerTests.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Azure.Gaming.VmAgent.UnitTests
+{
+    using System;
+    using System.Configuration;
+    using System.IO;
+    using System.Net.Http;
+    using System.Reflection;
+    using System.Text;
+    using System.Threading.Tasks;
+    using AgentInterfaces;
+    using Core.Interfaces;
+    using FluentAssertions;
+    using LocalMultiplayerAgent.Config;
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.AspNetCore.TestHost;
+    using Microsoft.Azure.Gaming.LocalMultiplayerAgent;
+    using Moq;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+    using VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class ControllerTests
+    {
+
+        private TestServer server;
+        protected HttpClient Client { get; private set; }
+
+        [TestMethod]
+        [TestCategory("BVT")]
+        public async Task ValidateStandingByToInitializingThrows()
+        {
+            this.server = new TestServer(new WebHostBuilder()
+                .UseStartup<Startup>());
+            this.Client = this.server.CreateClient();
+
+            string sessionHostId = "testSessionHostId";
+
+            // send the first heartbeat with "StandingBy"
+            SessionHostHeartbeatInfo heartbeat = new SessionHostHeartbeatInfo()
+            {
+                CurrentGameState = SessionHostStatus.StandingBy
+            };
+            var json = JsonConvert.SerializeObject(heartbeat);
+            var data = new StringContent(json, Encoding.UTF8, "application/json");
+            var value = await this.Client.PostAsync($"v1/sessionHosts/{sessionHostId}/heartbeats", data);
+
+            Assert.IsTrue(value.IsSuccessStatusCode);
+
+            // send the first heartbeat with "StandingBy"
+            heartbeat.CurrentGameState = SessionHostStatus.Initializing;
+            json = JsonConvert.SerializeObject(heartbeat);
+            data = new StringContent(json, Encoding.UTF8, "application/json");
+            
+            value = await this.Client.PostAsync($"v1/sessionHosts/{sessionHostId}/heartbeats", data);
+            Assert.IsFalse(value.IsSuccessStatusCode);
+            Assert.IsTrue(value.StatusCode == System.Net.HttpStatusCode.BadRequest);
+        }
+    }
+}

--- a/LocalMultiplayerAgent.UnitTest/LocalMultiplayerAgent.UnitTest.csproj
+++ b/LocalMultiplayerAgent.UnitTest/LocalMultiplayerAgent.UnitTest.csproj
@@ -11,6 +11,7 @@
   
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.7.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.27" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="Moq" Version="4.11.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />


### PR DESCRIPTION
This PR introduces a check for invalid state transitions between two subsequent heartbeat requests as well as a corresponding unit test. A couple of points

- the check for invalid state transition currently only checks for transition from StandingBy to Initializing. We expect to expand with more checks in the future
- we want to kill LocalMultiplayerAgent when an invalid transition happens. This is to facilitate running LMA in a CI/CD environment
- the way that we kill the LMA process is by using the IHostApplicationLifeTime object. We've used this way in [a Thundernetes sample](https://github.com/PlayFab/thundernetes/blob/main/samples/netcore/Controllers/HelloController.cs#L30) and has worked great so far. Not sure if there is a better way.