### PR TITLE
Add support for capturing the output of Processes

### DIFF
--- a/VmAgent.Core.UnitTests/ProcessOutputLoggerTest.cs
+++ b/VmAgent.Core.UnitTests/ProcessOutputLoggerTest.cs
@@ -3,9 +3,11 @@ using FluentAssertions;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Azure.Gaming.VmAgent.Core;
+using Microsoft.Azure.Gaming.VmAgent.Core.Dependencies.Interfaces;
 using Microsoft.Azure.Gaming.VmAgent.Core.UnitTests;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 using System;
 using VmAgent.Core.Dependencies.Interfaces.Exceptions;
 
@@ -14,17 +16,32 @@ namespace VmAgent.Core.UnitTests
     [TestClass]
     public class ProcessOutputLoggerTest
     {
+        private string _validPath = "C:\\PF_Consolelog.txt";
         private MultiLogger _multiLogger;
+        private Mock<IFileWriteWrapper> _fileWriteWrapper;
+        private ProcessOutputLogger _processLogger;
 
         [TestInitialize]
         public void BeforeEachTest()
         {
             _multiLogger = new MultiLogger(NullLogger.Instance, new TelemetryClient(TelemetryConfiguration.CreateDefault()));
+            _fileWriteWrapper = new Mock<IFileWriteWrapper>();
+
+            Mock<ProcessOutputLogger> mockProcessLogger = new Mock<ProcessOutputLogger>(
+               _validPath,
+               _multiLogger,
+               _fileWriteWrapper.Object)
+            {
+                CallBase = true
+            };
+
+            _processLogger = mockProcessLogger.Object;
         }
 
         [TestMethod, TestCategory("BVT")]
         [DataRow(null)]
         [DataRow("")]
+        [DataRow(" ")]
         public void InvalidLogFileNameFailed(string invalidFilePath)
         {
             ExceptionAssert.Throws<ProcessOuputLoggerCreationFailedException>(() => new ProcessOutputLogger(invalidFilePath, _multiLogger));
@@ -37,5 +54,24 @@ namespace VmAgent.Core.UnitTests
             ProcessOutputLogger processLogger = new ProcessOutputLogger(validFilePath, _multiLogger);
             processLogger.GetProcessLogFilePath().Should().Equals(validFilePath);
         }
+
+        [TestMethod, TestCategory("BVT")]
+        public void FileWriteFailDoNotThrowException()
+        {
+            _fileWriteWrapper.Setup(x => x.Write(It.IsAny<string>())).Throws(new Exception());
+
+            Action act = () => _processLogger.Log("test123");
+            act.Should().NotThrow();
+        }
+
+        [TestMethod, TestCategory("BVT")]
+        public void FileCloseFailDoNotThrowException()
+        {
+            _fileWriteWrapper.Setup(x => x.Close()).Throws(new Exception());
+            
+            Action act = () => _processLogger.Close();
+            act.Should().NotThrow();
+        }
+
     }
 }

--- a/VmAgent.Core.UnitTests/ProcessOutputLoggerTest.cs
+++ b/VmAgent.Core.UnitTests/ProcessOutputLoggerTest.cs
@@ -2,22 +2,11 @@
 using FluentAssertions;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Extensibility;
-using Microsoft.Azure.Gaming.VmAgent;
 using Microsoft.Azure.Gaming.VmAgent.Core;
-using Microsoft.Azure.Gaming.VmAgent.Core.Dependencies;
-using Microsoft.Azure.Gaming.VmAgent.Core.Interfaces;
 using Microsoft.Azure.Gaming.VmAgent.Core.UnitTests;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
 using VmAgent.Core.Dependencies.Interfaces.Exceptions;
 
 namespace VmAgent.Core.UnitTests
@@ -35,6 +24,8 @@ namespace VmAgent.Core.UnitTests
 
         [TestMethod, TestCategory("BVT")]
         [DataRow(null)]
+        [DataRow("")]
+        [DataRow("\\abc")]
         public void InvalidLogFileNameFailed(string invalidFilePath)
         {
             ExceptionAssert.Throws<ProcessOuputLoggerCreationFailedException>(() => new ProcessOutputLogger(invalidFilePath, _multiLogger));
@@ -46,6 +37,28 @@ namespace VmAgent.Core.UnitTests
         {
             ProcessOutputLogger processLogger = new ProcessOutputLogger(validFilePath, _multiLogger);
             processLogger.GetProcessLogFilePath().Should().Equals(validFilePath);
+        }
+
+        [TestMethod, TestCategory("BVT")]
+        public void CloseFileAfterCloseDoNotThrowException()
+        {
+            string fileFilePath = "C:\\PF_Consolelog.txt";
+            ProcessOutputLogger processLogger = new ProcessOutputLogger(fileFilePath, _multiLogger);
+            processLogger.Close();
+            
+            Action act = () => processLogger.Close();
+            act.Should().NotThrow();
+        }
+
+        [TestMethod, TestCategory("BVT")]
+        public void LogToFileAfterCloseFileDoNotThrowException()
+        {
+            string fileFilePath = "C:\\PF_Consolelog.txt";
+            ProcessOutputLogger processLogger = new ProcessOutputLogger(fileFilePath, _multiLogger);
+            processLogger.Close();
+            
+            Action act = () => processLogger.Log("ABCD");
+            act.Should().NotThrow();
         }
     }
 }

--- a/VmAgent.Core.UnitTests/ProcessOutputLoggerTest.cs
+++ b/VmAgent.Core.UnitTests/ProcessOutputLoggerTest.cs
@@ -58,7 +58,7 @@ namespace VmAgent.Core.UnitTests
         [TestMethod, TestCategory("BVT")]
         public void FileWriteFailDoNotThrowException()
         {
-            _fileWriteWrapper.Setup(x => x.Write(It.IsAny<string>())).Throws(new Exception());
+            _fileWriteWrapper.Setup(x => x.Write(It.IsAny<string>(), It.IsAny<string>())).Throws(new InvalidOperationException());
 
             Action act = () => _processLogger.Log("test123");
             act.Should().NotThrow();

--- a/VmAgent.Core.UnitTests/ProcessOutputLoggerTest.cs
+++ b/VmAgent.Core.UnitTests/ProcessOutputLoggerTest.cs
@@ -1,0 +1,51 @@
+﻿
+using FluentAssertions;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.Azure.Gaming.VmAgent;
+using Microsoft.Azure.Gaming.VmAgent.Core;
+using Microsoft.Azure.Gaming.VmAgent.Core.Dependencies;
+using Microsoft.Azure.Gaming.VmAgent.Core.Interfaces;
+using Microsoft.Azure.Gaming.VmAgent.Core.UnitTests;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using VmAgent.Core.Dependencies.Interfaces.Exceptions;
+
+namespace VmAgent.Core.UnitTests
+{
+    [TestClass]
+    public class ProcessOutputLoggerTest
+    {
+        private MultiLogger _multiLogger;
+
+        [TestInitialize]
+        public void BeforeEachTest()
+        {
+            _multiLogger = new MultiLogger(NullLogger.Instance, new TelemetryClient(TelemetryConfiguration.CreateDefault()));
+        }
+
+        [TestMethod, TestCategory("BVT")]
+        [DataRow(null)]
+        public void InvalidLogFileNameFailed(string invalidFilePath)
+        {
+            ExceptionAssert.Throws<ProcessOuputLoggerCreationFailedException>(() => new ProcessOutputLogger(invalidFilePath, _multiLogger));
+        }
+
+        [TestMethod, TestCategory("BVT")]
+        [DataRow("C:\\PF_Consolelog.txt")]
+        public void ValidLogFileNameReturnFilePath(string validFilePath)
+        {
+            ProcessOutputLogger processLogger = new ProcessOutputLogger(validFilePath, _multiLogger);
+            processLogger.GetProcessLogFilePath().Should().Equals(validFilePath);
+        }
+    }
+}

--- a/VmAgent.Core.UnitTests/ProcessOutputLoggerTest.cs
+++ b/VmAgent.Core.UnitTests/ProcessOutputLoggerTest.cs
@@ -25,7 +25,6 @@ namespace VmAgent.Core.UnitTests
         [TestMethod, TestCategory("BVT")]
         [DataRow(null)]
         [DataRow("")]
-        [DataRow("\\abc")]
         public void InvalidLogFileNameFailed(string invalidFilePath)
         {
             ExceptionAssert.Throws<ProcessOuputLoggerCreationFailedException>(() => new ProcessOutputLogger(invalidFilePath, _multiLogger));
@@ -37,28 +36,6 @@ namespace VmAgent.Core.UnitTests
         {
             ProcessOutputLogger processLogger = new ProcessOutputLogger(validFilePath, _multiLogger);
             processLogger.GetProcessLogFilePath().Should().Equals(validFilePath);
-        }
-
-        [TestMethod, TestCategory("BVT")]
-        public void CloseFileAfterCloseDoNotThrowException()
-        {
-            string fileFilePath = "C:\\PF_Consolelog.txt";
-            ProcessOutputLogger processLogger = new ProcessOutputLogger(fileFilePath, _multiLogger);
-            processLogger.Close();
-            
-            Action act = () => processLogger.Close();
-            act.Should().NotThrow();
-        }
-
-        [TestMethod, TestCategory("BVT")]
-        public void LogToFileAfterCloseFileDoNotThrowException()
-        {
-            string fileFilePath = "C:\\PF_Consolelog.txt";
-            ProcessOutputLogger processLogger = new ProcessOutputLogger(fileFilePath, _multiLogger);
-            processLogger.Close();
-            
-            Action act = () => processLogger.Log("ABCD");
-            act.Should().NotThrow();
         }
     }
 }

--- a/VmAgent.Core/Dependencies/FileWriteWrapper.cs
+++ b/VmAgent.Core/Dependencies/FileWriteWrapper.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Azure.Gaming.VmAgent.Core.Dependencies
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.IO;
+    using ApplicationInsights;
+    using ApplicationInsights.DataContracts;
+    using global::VmAgent.Core.Dependencies.Interfaces.Exceptions;
+    using Microsoft.Azure.Gaming.VmAgent.Core.Dependencies.Interfaces;
+    using Microsoft.Extensions.Logging;
+    using Newtonsoft.Json;
+
+    public class FileWriteWrapper : IFileWriteWrapper
+    {
+        private string _logFilePath;
+        private StreamWriter _logWriter;
+
+        public FileWriteWrapper()
+        {
+        }
+
+        public void CreateFile(string logFilePath)
+        {
+            _logFilePath = logFilePath;
+            _logWriter = new StreamWriter(File.OpenWrite(logFilePath));
+        }
+
+        public bool Close()
+        {
+            if (_logWriter != null)
+            {
+                _logWriter.Close();
+                _logWriter = null;
+
+                return true;
+            }
+            return false;
+        }
+
+        public void Write(string message)
+        {
+            if (_logWriter != null)
+            {
+                string currentDate = DateTime.Now.ToString("yyyy-MM-dd'T'HH:mm:ss.fffK");
+
+                _logWriter.WriteLine($"{currentDate}\t{message}");
+                _logWriter.Flush();
+            }
+            else
+            {
+                new Exception($"StreamWriter is null or already closed. Cannot write a log to a file {_logFilePath}");
+            }
+        }
+
+        public string GetProcessLogFilePath()
+        {
+            return _logFilePath;
+        }
+    }
+}

--- a/VmAgent.Core/Dependencies/FileWriteWrapper.cs
+++ b/VmAgent.Core/Dependencies/FileWriteWrapper.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Dependencies
             {
                 string currentDate = DateTime.Now.ToString("yyyy-MM-dd'T'HH:mm:ss.fffK");
 
-                _textWriter.Write($"{{\"log\":\"{message}\", \"stream\":{streamType}, \"time\":{currentDate}}}");
+                _textWriter.WriteLine($"{{\"log\":\"{message}\", \"stream\":{streamType}, \"time\":{currentDate}}}");
                 _textWriter.Flush();
             }
             else

--- a/VmAgent.Core/Dependencies/FileWriteWrapper.cs
+++ b/VmAgent.Core/Dependencies/FileWriteWrapper.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Dependencies
     public class FileWriteWrapper : IFileWriteWrapper
     {
         private string _logFilePath;
-        private StreamWriter _logWriter;
+        private TextWriter _textWriter;
 
         public FileWriteWrapper()
         {
@@ -26,33 +26,33 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Dependencies
         public void CreateFile(string logFilePath)
         {
             _logFilePath = logFilePath;
-            _logWriter = new StreamWriter(File.OpenWrite(logFilePath));
+            _textWriter = TextWriter.Synchronized(new StreamWriter(File.OpenWrite(logFilePath)));
         }
 
         public bool Close()
         {
-            if (_logWriter != null)
+            if (_textWriter != null)
             {
-                _logWriter.Close();
-                _logWriter = null;
+                _textWriter.Close();
+                _textWriter = null;
 
                 return true;
             }
             return false;
         }
 
-        public void Write(string message)
+        public void Write(string message, string streamType = "stdout")
         {
-            if (_logWriter != null)
+            if (_textWriter != null)
             {
                 string currentDate = DateTime.Now.ToString("yyyy-MM-dd'T'HH:mm:ss.fffK");
 
-                _logWriter.WriteLine($"{currentDate}\t{message}");
-                _logWriter.Flush();
+                _textWriter.Write($"{{\"log\":\"{message}\", \"stream\":{streamType}, \"time\":{currentDate}}}");
+                _textWriter.Flush();
             }
             else
             {
-                new Exception($"StreamWriter is null or already closed. Cannot write a log to a file {_logFilePath}");
+                new InvalidOperationException($"StreamWriter is null or already closed. Cannot write a log to a file {_logFilePath}");
             }
         }
 

--- a/VmAgent.Core/Dependencies/FileWriteWrapper.cs
+++ b/VmAgent.Core/Dependencies/FileWriteWrapper.cs
@@ -45,9 +45,10 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Dependencies
         {
             if (_textWriter != null)
             {
-                string currentDate = DateTime.Now.ToString("yyyy-MM-dd'T'HH:mm:ss.fffK");
+                string currentDate = DateTime.UtcNow.ToString("o");
+                string logMessage = $"{{\"log\":{JsonConvert.ToString(message)}, \"stream\":\"{streamType}\", \"time\":\"{currentDate}\"}}";
 
-                _textWriter.WriteLine($"{{\"log\":\"{message}\", \"stream\":{streamType}, \"time\":{currentDate}}}");
+                _textWriter.WriteLine(logMessage);
                 _textWriter.Flush();
             }
             else

--- a/VmAgent.Core/Dependencies/Interfaces/Exceptions/ProcessOutputLoggerCreationFailedException.cs
+++ b/VmAgent.Core/Dependencies/Interfaces/Exceptions/ProcessOutputLoggerCreationFailedException.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace VmAgent.Core.Dependencies.Interfaces.Exceptions
+{
+    [Serializable]
+    public class ProcessOuputLoggerCreationFailedException : Exception
+    {
+        public ProcessOuputLoggerCreationFailedException(string message) : base(message)
+        {
+          
+        }
+
+        protected ProcessOuputLoggerCreationFailedException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+           
+        }
+
+    }
+}

--- a/VmAgent.Core/Dependencies/Interfaces/IFileWriteWrapper.cs
+++ b/VmAgent.Core/Dependencies/Interfaces/IFileWriteWrapper.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Dependencies.Interfaces
     public interface IFileWriteWrapper 
     {
         public void CreateFile(string logFilePath);
-        public void Write(string message);
+        public void Write(string message, string streamType = "stdout");
         public string GetProcessLogFilePath();
         bool Close();
     }

--- a/VmAgent.Core/Dependencies/Interfaces/IFileWriteWrapper.cs
+++ b/VmAgent.Core/Dependencies/Interfaces/IFileWriteWrapper.cs
@@ -8,8 +8,11 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Dependencies.Interfaces
     public interface IFileWriteWrapper 
     {
         public void CreateFile(string logFilePath);
-        public void Write(string message, string streamType = "stdout");
+
+        public void Write(string message, string streamType);
+
         public string GetProcessLogFilePath();
+
         bool Close();
     }
 }

--- a/VmAgent.Core/Dependencies/Interfaces/IFileWriteWrapper.cs
+++ b/VmAgent.Core/Dependencies/Interfaces/IFileWriteWrapper.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+
+namespace Microsoft.Azure.Gaming.VmAgent.Core.Dependencies.Interfaces
+{
+    public interface IFileWriteWrapper 
+    {
+        public void CreateFile(string logFilePath);
+        public void Write(string message);
+        public string GetProcessLogFilePath();
+        bool Close();
+    }
+}

--- a/VmAgent.Core/Dependencies/Interfaces/IProcessOutputLogger.cs
+++ b/VmAgent.Core/Dependencies/Interfaces/IProcessOutputLogger.cs
@@ -7,8 +7,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Dependencies.Interfaces
 {
     public interface IProcessOutputLogger 
     {
-        void Log(string message);
-
+        void Log(string message, string streamType);
         string GetProcessLogFilePath();
 
         void Close();

--- a/VmAgent.Core/Dependencies/Interfaces/IProcessOutputLogger.cs
+++ b/VmAgent.Core/Dependencies/Interfaces/IProcessOutputLogger.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+
+namespace Microsoft.Azure.Gaming.VmAgent.Core.Dependencies.Interfaces
+{
+    public interface IProcessOutputLogger 
+    {
+        void Log(string message);
+
+        string GetProcessLogFilePath();
+
+        void Close();
+
+        void ErrorOutputHandler(object sendingProcess, DataReceivedEventArgs outLine);
+
+        void StdOutputHandler(object sendingProcess, DataReceivedEventArgs outLine);
+    }
+}

--- a/VmAgent.Core/Dependencies/Interfaces/IProcessOutputLogger.cs
+++ b/VmAgent.Core/Dependencies/Interfaces/IProcessOutputLogger.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Dependencies.Interfaces
     public interface IProcessOutputLogger 
     {
         void Log(string message, string streamType);
+
         string GetProcessLogFilePath();
 
         void Close();

--- a/VmAgent.Core/Interfaces/BaseSessionHostRunner.cs
+++ b/VmAgent.Core/Interfaces/BaseSessionHostRunner.cs
@@ -38,8 +38,6 @@ namespace Microsoft.Azure.Gaming.VmAgent.ContainerEngines
 
         abstract public Task CollectLogs(string id, string logsFolder, ISessionHostManager sessionHostManager);
 
-        abstract public Task CreateStartGameExceptionLogs(string logsFolder, string exceptionMessage);
-
         abstract public Task<SessionHostInfo> CreateAndStart(int instanceNumber, GameResourceDetails gameResourceDetails, ISessionHostManager sessionHostManager);
 
         abstract public Task DeleteResources(SessionHostsStartInfo sessionHostsStartInfo);

--- a/VmAgent.Core/Interfaces/DockerContainerEngine.cs
+++ b/VmAgent.Core/Interfaces/DockerContainerEngine.cs
@@ -659,10 +659,5 @@ namespace Microsoft.Azure.Gaming.VmAgent.ContainerEngines
             }
             return null;
         }
-
-        public override Task CreateStartGameExceptionLogs(string logsFolder, string exceptionMessage)
-        {
-            return Task.CompletedTask;
-        }
     }
 }

--- a/VmAgent.Core/Interfaces/IProcessWrapper.cs
+++ b/VmAgent.Core/Interfaces/IProcessWrapper.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
 
         int Start(ProcessStartInfo startInfo);
 
-        int StartWithEventHandler(ProcessStartInfo startInfo, Action<object, DataReceivedEventArgs> StdOutputHandler, Action<object, DataReceivedEventArgs> ErrorOutputHandler, Action<object, EventArgs> ProcessExitedHanlder);
+        int StartWithEventHandler(ProcessStartInfo startInfo, Action<object, DataReceivedEventArgs> StdOutputHandler, Action<object, DataReceivedEventArgs> ErrorOutputHandler, Action<object, EventArgs> ProcessExitedHandler);
 
         IEnumerable<int> List();
 

--- a/VmAgent.Core/Interfaces/IProcessWrapper.cs
+++ b/VmAgent.Core/Interfaces/IProcessWrapper.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
 {
+    using System;
     using System.Collections.Generic;
     using System.Diagnostics;
 
@@ -11,6 +12,8 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
         void Kill(int id);
 
         int Start(ProcessStartInfo startInfo);
+
+        int StartWithEventHandler(ProcessStartInfo startInfo, Action<object, DataReceivedEventArgs> StdOutputHandler, Action<object, DataReceivedEventArgs> ErrorOutputHandler);
 
         IEnumerable<int> List();
 

--- a/VmAgent.Core/Interfaces/IProcessWrapper.cs
+++ b/VmAgent.Core/Interfaces/IProcessWrapper.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
 
         int Start(ProcessStartInfo startInfo);
 
-        int StartWithEventHandler(ProcessStartInfo startInfo, Action<object, DataReceivedEventArgs> StdOutputHandler, Action<object, DataReceivedEventArgs> ErrorOutputHandler);
+        int StartWithEventHandler(ProcessStartInfo startInfo, Action<object, DataReceivedEventArgs> StdOutputHandler, Action<object, DataReceivedEventArgs> ErrorOutputHandler, Action<object, EventArgs> ProcessExitedHanlder);
 
         IEnumerable<int> List();
 

--- a/VmAgent.Core/Interfaces/ISessionHostRunner.cs
+++ b/VmAgent.Core/Interfaces/ISessionHostRunner.cs
@@ -26,6 +26,5 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
 
         Task CollectLogs(string id, string logsFolder, ISessionHostManager sessionHostManager);
 
-        Task CreateStartGameExceptionLogs(string logFolder, string exceptionMessage);
     }
 }

--- a/VmAgent.Core/Interfaces/ProcessRunner.cs
+++ b/VmAgent.Core/Interfaces/ProcessRunner.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
             try
             {
                 int processId = processOutputLogger != null ? 
-                    _processWrapper.StartWithEventHandler(processStartInfo, processOutputLogger.StdOutputHandler, processOutputLogger.ErrorOutputHandler) : _processWrapper.Start(processStartInfo);
+                    _processWrapper.StartWithEventHandler(processStartInfo, processOutputLogger.StdOutputHandler, processOutputLogger.ErrorOutputHandler, processOutputLogger.ProcessExitedHanlder) : _processWrapper.Start(processStartInfo);
 
                 sessionHostManager.UpdateSessionHostTypeSpecificId(sessionHostUniqueId, processId.ToString());
                 _logger.LogInformation($"Started process for session host. Instance Number: {instanceNumber}, UniqueId: {sessionHostUniqueId}, ProcessId: {processId}");
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
                 }
                 else
                 {
-                    _logger.LogVerbose($"processOutputlogger is not initialized. Failed to write failed start game error logs to {ConsoleLogCaptureFileName} for Process.");
+                    _logger.LogException($"processOutputlogger is not initialized. Failed to write failed start game error logs to {ConsoleLogCaptureFileName} for Process.", exception);
                 }
             }
             return Task.FromResult(sessionHost);
@@ -102,19 +102,18 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
             return Task.CompletedTask;
         }
 
-        public void CreateStartGameExceptionLogs(ProcessOutputLogger processOutputlogger, string exceptionMessage)
+        public void CreateStartGameExceptionLogs(ProcessOutputLogger processOutputLogger, string exceptionMessage)
         {
             try
             {
                 _logger.LogVerbose("Collecting logs for failed start game process.");
-                _logger.LogVerbose($"Written logs for failed start game process to {processOutputlogger.GetProcessLogFilePath()}.");
-                processOutputlogger.Log(exceptionMessage);
+                _logger.LogVerbose($"Written logs for failed start game process to {processOutputLogger.GetProcessLogFilePath()}.");
+                processOutputLogger.Log(exceptionMessage);
 
             }
             catch (Exception ex)
             {
                 _logger.LogException($"Failed to write failed start game error logs for process", ex);
-                processOutputlogger.Log(ex.ToString());
             }
         }
 

--- a/VmAgent.Core/Interfaces/ProcessRunner.cs
+++ b/VmAgent.Core/Interfaces/ProcessRunner.cs
@@ -81,8 +81,15 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
                 sessionHostManager.RemoveSessionHost(sessionHostUniqueId);
                 sessionHost = null;
                 string exceptionMessage = exception.ToString();
-                
-                CreateStartGameExceptionLogs(processOutputLogger, exceptionMessage);
+
+                if (processOutputLogger != null)
+                {
+                    CreateStartGameExceptionLogs(processOutputLogger, exceptionMessage);
+                }
+                else
+                {
+                    _logger.LogVerbose($"processOutputlogger is not initialized. Failed to write failed start game error logs to {ConsoleLogCaptureFileName} for Process.");
+                }
             }
             return Task.FromResult(sessionHost);
         }

--- a/VmAgent.Core/Interfaces/ProcessRunner.cs
+++ b/VmAgent.Core/Interfaces/ProcessRunner.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
             try
             {
                 int processId = processOutputLogger != null ? 
-                    _processWrapper.StartWithEventHandler(processStartInfo, processOutputLogger.StdOutputHandler, processOutputLogger.ErrorOutputHandler, processOutputLogger.ProcessExitedHanlder) : _processWrapper.Start(processStartInfo);
+                    _processWrapper.StartWithEventHandler(processStartInfo, processOutputLogger.StdOutputHandler, processOutputLogger.ErrorOutputHandler, processOutputLogger.ProcessExitedHandler) : _processWrapper.Start(processStartInfo);
 
                 sessionHostManager.UpdateSessionHostTypeSpecificId(sessionHostUniqueId, processId.ToString());
                 _logger.LogInformation($"Started process for session host. Instance Number: {instanceNumber}, UniqueId: {sessionHostUniqueId}, ProcessId: {processId}");

--- a/VmAgent.Core/Interfaces/ProcessWrapper.cs
+++ b/VmAgent.Core/Interfaces/ProcessWrapper.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
             return Process.Start(startInfo).Id;
         }
 
-        public int StartWithEventHandler(ProcessStartInfo startInfo, Action<object, DataReceivedEventArgs> StdOutputHandler, Action<object, DataReceivedEventArgs> ErrorOutputHandler, Action<object, EventArgs> ProcessExitedHanlder)
+        public int StartWithEventHandler(ProcessStartInfo startInfo, Action<object, DataReceivedEventArgs> StdOutputHandler, Action<object, DataReceivedEventArgs> ErrorOutputHandler, Action<object, EventArgs> ProcessExitedHandler)
         {
             startInfo.RedirectStandardOutput = true;
             startInfo.RedirectStandardError = true;
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
             process.StartInfo = startInfo;
             process.OutputDataReceived += new DataReceivedEventHandler(StdOutputHandler);
             process.ErrorDataReceived += new DataReceivedEventHandler(ErrorOutputHandler);
-            process.Exited += new EventHandler(ProcessExitedHanlder);
+            process.Exited += new EventHandler(ProcessExitedHandler);
             process.EnableRaisingEvents = true;
             process.Start();
             process.BeginOutputReadLine();

--- a/VmAgent.Core/Interfaces/ProcessWrapper.cs
+++ b/VmAgent.Core/Interfaces/ProcessWrapper.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
             return Process.Start(startInfo).Id;
         }
 
-        public int StartWithEventHandler(ProcessStartInfo startInfo, Action<object, DataReceivedEventArgs> StdOutputHandler, Action<object, DataReceivedEventArgs> ErrorOutputHandler)
+        public int StartWithEventHandler(ProcessStartInfo startInfo, Action<object, DataReceivedEventArgs> StdOutputHandler, Action<object, DataReceivedEventArgs> ErrorOutputHandler, Action<object, EventArgs> ProcessExitedHanlder)
         {
             startInfo.RedirectStandardOutput = true;
             startInfo.RedirectStandardError = true;
@@ -43,6 +43,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
             process.StartInfo = startInfo;
             process.OutputDataReceived += new DataReceivedEventHandler(StdOutputHandler);
             process.ErrorDataReceived += new DataReceivedEventHandler(ErrorOutputHandler);
+            process.Exited += new EventHandler(ProcessExitedHanlder);
             process.EnableRaisingEvents = true;
             process.Start();
             process.BeginOutputReadLine();

--- a/VmAgent.Core/Interfaces/ProcessWrapper.cs
+++ b/VmAgent.Core/Interfaces/ProcessWrapper.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
-    using System.Threading.Tasks;
 
     public class ProcessWrapper : IProcessWrapper
     {
@@ -33,6 +32,23 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
         public int Start(ProcessStartInfo startInfo)
         {
             return Process.Start(startInfo).Id;
+        }
+
+        public int StartWithEventHandler(ProcessStartInfo startInfo, Action<object, DataReceivedEventArgs> StdOutputHandler, Action<object, DataReceivedEventArgs> ErrorOutputHandler)
+        {
+            startInfo.RedirectStandardOutput = true;
+            startInfo.RedirectStandardError = true;
+
+            Process process = new Process();
+            process.StartInfo = startInfo;
+            process.OutputDataReceived += new DataReceivedEventHandler(StdOutputHandler);
+            process.ErrorDataReceived += new DataReceivedEventHandler(ErrorOutputHandler);
+            process.EnableRaisingEvents = true;
+            process.Start();
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
+            return process.Id;
         }
 
         public IEnumerable<int> List()

--- a/VmAgent.Core/ProcessOutputLogger.cs
+++ b/VmAgent.Core/ProcessOutputLogger.cs
@@ -39,11 +39,11 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core
                 Close();
             }
         }
-        public void Log(string message)
+        public void Log(string message, string streamType = "stdout")
         {
             try
             {
-                _fileWriteWrapper.Write(message);
+                _fileWriteWrapper.Write(message, streamType);
             }
             catch(Exception ex)
             {
@@ -80,19 +80,18 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core
 
         public void ErrorOutputHandler(object sendingProcess, DataReceivedEventArgs outLine)
         {
-            Process p = sendingProcess as Process;
-            if (p != null)
-            {
-                _logger.LogInformation($"ErrorOutputHandler was triggered - ProcessId: {p.Id}");
-            }
-
-            Log(outLine.Data);
-            Close();
+            Log(outLine.Data, "stderr");
         }
 
         public void StdOutputHandler(object sendingProcess, DataReceivedEventArgs outLine)
         {
             Log(outLine.Data);
+        }
+
+        public void ProcessExitedHanlder(object sendingProcess, EventArgs outLine)
+        {
+            Log("Process is terminated.");
+            Close();
         }
     }
 }

--- a/VmAgent.Core/ProcessOutputLogger.cs
+++ b/VmAgent.Core/ProcessOutputLogger.cs
@@ -22,9 +22,9 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core
 
         public ProcessOutputLogger(string logFilePath, MultiLogger logger)
         {
-            if (logFilePath == null)
+            if (String.IsNullOrEmpty(logFilePath))
             {
-                throw new ProcessOuputLoggerCreationFailedException($"LogFilePath cannot be null.");
+                throw new ProcessOuputLoggerCreationFailedException($"LogFilePath cannot be null or empty.");
             }
 
             try
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core
             }
             catch (Exception ex)
             {
-                _logger.LogInformation($"Exception was thrown while creating a Process Log file under {_logFilePath}. {ex}");
+                _logger.LogInformation($"Exception was thrown while creating a Process Log file under. {ex}");
                 throw new ProcessOuputLoggerCreationFailedException($"Process Output Logger failed to create a file. {ex}.");
             }
 
@@ -86,7 +86,14 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core
             }
 
             Log(outLine.Data);
-            Close();
+            try
+            {
+                Close();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogInformation($"Exception was thrown while closing a file. {ex}");
+            }
         }
 
         public void StdOutputHandler(object sendingProcess, DataReceivedEventArgs outLine)

--- a/VmAgent.Core/ProcessOutputLogger.cs
+++ b/VmAgent.Core/ProcessOutputLogger.cs
@@ -1,0 +1,91 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Azure.Gaming.VmAgent.Core
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.IO;
+    using ApplicationInsights;
+    using ApplicationInsights.DataContracts;
+    using global::VmAgent.Core.Dependencies.Interfaces.Exceptions;
+    using Microsoft.Azure.Gaming.VmAgent.Core.Dependencies.Interfaces;
+    using Microsoft.Extensions.Logging;
+    using Newtonsoft.Json;
+
+    public class ProcessOutputLogger: IProcessOutputLogger
+    {
+        private string _logFilePath;
+        private StreamWriter _logWriter;
+        private MultiLogger _logger;
+
+        public ProcessOutputLogger(string logFilePath, MultiLogger logger)
+        {
+            if (logFilePath == null)
+            {
+                throw new ProcessOuputLoggerCreationFailedException($"LogFilePath cannot be null.");
+            }
+
+            try
+            {
+                _logWriter = new StreamWriter(File.OpenWrite(logFilePath));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogInformation($"Exception was thrown during Process output Log file creation under {_logFilePath}. {ex}");
+                throw new ProcessOuputLoggerCreationFailedException($"Process Output Logger failed to create a file. {ex}.");
+            }
+
+            _logFilePath = logFilePath;
+            _logger = logger;
+
+            _logger.LogInformation($"Process Log file is created under {_logFilePath}");
+        }
+
+        public void Log(string message)
+        {
+            if (_logWriter == null)
+            {
+                _logger.LogInformation($"StreamWriter is null or not created yet.");
+                return;
+            }
+
+            string currentDate = DateTime.Now.ToString("yyyy-MM-dd'T'HH:mm:ss.fffK");
+
+            _logWriter.WriteLine($"{currentDate}\t{message}");
+            _logWriter.Flush();
+        }
+
+        public string GetProcessLogFilePath()
+        {
+            return _logFilePath;
+        }
+
+        public void Close()
+        {
+            _logger.LogInformation($"closing file {_logFilePath}");
+
+            if (_logWriter != null)
+            {
+                _logger.LogInformation($"can't close a log file - {_logFilePath}. StreamWriter is already null.");
+                _logWriter.Close();
+                _logWriter = null;
+            }
+        }
+
+        public void ErrorOutputHandler(object sendingProcess, DataReceivedEventArgs outLine)
+        {
+            Process p = sendingProcess as Process;
+            _logger.LogInformation($"ErrorOutputHandler ProcessId: {p.Id} : Error is captured by EventHandler. Target File Path : {GetProcessLogFilePath()}. Closing file...");
+
+            Log(outLine.Data);
+            Close();
+        }
+
+        public void StdOutputHandler(object sendingProcess, DataReceivedEventArgs outLine)
+        {
+            Log(outLine.Data);
+        }
+    }
+}

--- a/VmAgent.Core/ProcessOutputLogger.cs
+++ b/VmAgent.Core/ProcessOutputLogger.cs
@@ -88,9 +88,8 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core
             Log(outLine.Data);
         }
 
-        public void ProcessExitedHanlder(object sendingProcess, EventArgs outLine)
+        public void ProcessExitedHandler(object sendingProcess, EventArgs outLine)
         {
-            Log("Process is terminated.");
             Close();
         }
     }

--- a/VmAgent.Core/ProcessOutputLogger.cs
+++ b/VmAgent.Core/ProcessOutputLogger.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core
             }
             catch (Exception ex)
             {
-                _logger.LogInformation($"Exception was thrown while closing a file. {ex}");
+                _logger.LogException($"Exception was thrown while closing a file.", ex);
             }
         }
 

--- a/VmAgent.Core/ProcessOutputLogger.cs
+++ b/VmAgent.Core/ProcessOutputLogger.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core
             }
             catch (Exception ex)
             {
-                _logger.LogInformation($"Exception was thrown during Process output Log file creation under {_logFilePath}. {ex}");
+                _logger.LogInformation($"Exception was thrown while creating a Process Log file under {_logFilePath}. {ex}");
                 throw new ProcessOuputLoggerCreationFailedException($"Process Output Logger failed to create a file. {ex}.");
             }
 
@@ -64,20 +64,26 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core
 
         public void Close()
         {
-            _logger.LogInformation($"closing file {_logFilePath}");
+            _logger.LogInformation($"Closing a Process Log file... Target File Path : {GetProcessLogFilePath()}. ");
 
             if (_logWriter != null)
             {
-                _logger.LogInformation($"can't close a log file - {_logFilePath}. StreamWriter is already null.");
                 _logWriter.Close();
                 _logWriter = null;
+            }
+            else
+            {
+                _logger.LogInformation($"Cannot close {_logFilePath}. StreamWriter is already null.");
             }
         }
 
         public void ErrorOutputHandler(object sendingProcess, DataReceivedEventArgs outLine)
         {
             Process p = sendingProcess as Process;
-            _logger.LogInformation($"ErrorOutputHandler ProcessId: {p.Id} : Error is captured by EventHandler. Target File Path : {GetProcessLogFilePath()}. Closing file...");
+            if (p != null)
+            {
+                _logger.LogInformation($"ErrorOutputHandler was triggered - ProcessId: {p.Id}");
+            }
 
             Log(outLine.Data);
             Close();


### PR DESCRIPTION
This code supports capturing stderr and stdout logs of Processes. 
When Process object is created, Start Information is configured with event handlers to subscribe to events and redirect streams of standard output/errors to the event handlers. Whenever events are raised to event handlers, it writes them to the **PF_ConsoleLog.txt** until process is terminated or error is captured. 

Sample Output For Windows Process:
[PF_ConsoleLogs.txt](https://github.com/PlayFab/MpsAgent/files/9377768/PF_ConsoleLogs.txt)
Sample Output For Linux Process:
[PF_ConsoleLogs(Linux).txt](https://github.com/PlayFab/MpsAgent/files/9377801/PF_ConsoleLogs.Linux.txt)


