### PR TITLE
add support for pull images by digest

### DIFF
--- a/AgentInterfaces/ContainerImageDetails.cs
+++ b/AgentInterfaces/ContainerImageDetails.cs
@@ -21,6 +21,11 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
         public string ImageTag { get; set; }
 
         /// <summary>
+        /// Digest of the container image. Takes precedence over the tag if present.
+        /// </summary>
+        public string ImageDigest { get; set; }
+
+        /// <summary>
         /// Username to use to authenticate to the container registry. 
         /// </summary>
         public string Username { get; set; }

--- a/VmAgent.Core.UnitTests/DockerContainerEngineTests.cs
+++ b/VmAgent.Core.UnitTests/DockerContainerEngineTests.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Microsoft.Azure.Gaming.VmAgent.ContainerEngines;
+using Microsoft.Azure.Gaming.AgentInterfaces;
+
+namespace VmAgent.Core.UnitTests
+{
+    [TestClass]
+    public class DockerContainerEngineTests
+    {
+        [TestInitialize]
+        public void BeforeEachTest()
+        {
+        }
+
+        [TestMethod]
+        [TestCategory("BVT")]
+        public void TestGetImageNameWithTag()
+        {
+            var imageDetails = new ContainerImageDetails
+            {
+                ImageName = "name",
+                ImageTag = "tag",
+                ImageDigest = null,
+                Registry = null,
+            };
+            Assert.AreEqual("name:tag", DockerContainerEngine.GetImageNameFromContainerImageDetails(imageDetails));
+
+            imageDetails.Registry = "registry";
+            Assert.AreEqual("registry/name:tag", DockerContainerEngine.GetImageNameFromContainerImageDetails(imageDetails));
+        }
+
+        [TestMethod]
+        [TestCategory("BVT")]
+        public void TestGetImageNameWithDigest()
+        {
+            var imageDetails = new ContainerImageDetails
+            {
+                ImageName = "name",
+                ImageTag = "tag",
+                ImageDigest = "digest",
+                Registry = null,
+            };
+            Assert.AreEqual("name@digest", DockerContainerEngine.GetImageNameFromContainerImageDetails(imageDetails));
+
+            imageDetails.Registry = "registry";
+            Assert.AreEqual("registry/name@digest", DockerContainerEngine.GetImageNameFromContainerImageDetails(imageDetails));
+        }
+    }
+}

--- a/VmAgent.Core/Interfaces/DockerContainerEngine.cs
+++ b/VmAgent.Core/Interfaces/DockerContainerEngine.cs
@@ -353,13 +353,8 @@ namespace Microsoft.Azure.Gaming.VmAgent.ContainerEngines
             // is the same as the remote image path.
             SessionHostsStartInfo sessionHostStartInfo = gameResourceDetails.SessionHostsStartInfo;
             ContainerImageDetails imageDetails = sessionHostStartInfo.ImageDetails;
-            string imageName = $"{imageDetails.ImageName}:{imageDetails.ImageTag ?? "latest"}";
 
-            // Support running local images with no explicit registry in the name.
-            if (!string.IsNullOrEmpty(imageDetails.Registry))
-            {
-                imageName = $"{imageDetails.Registry}/{imageName}";
-            }
+            string imageName = GetImageNameFromContainerImageDetails(imageDetails);
 
             // The game containers need a unique folder to write their logs. Ideally,
             // we would specify the containerId itself as the subfolder. However, we have to
@@ -413,6 +408,27 @@ namespace Microsoft.Azure.Gaming.VmAgent.ContainerEngines
 
 
             return sessionHost;
+        }
+
+        public static string GetImageNameFromContainerImageDetails(ContainerImageDetails imageDetails)
+        {
+            string imageName;
+            if (!string.IsNullOrEmpty(imageDetails.ImageDigest))
+            {
+                imageName = $"{imageDetails.ImageName}@{imageDetails.ImageDigest}";
+            }
+            else
+            {
+                imageName = $"{imageDetails.ImageName}:{imageDetails.ImageTag ?? "latest"}";
+            }
+
+            // Support running local images with no explicit registry in the name.
+            if (!string.IsNullOrEmpty(imageDetails.Registry))
+            {
+                imageName = $"{imageDetails.Registry}/{imageName}";
+            }
+
+            return imageName;
         }
 
         private IList<string> GetVolumeBindings(SessionHostsStartInfo request, int sessionHostInstance, string logFolderId, VmAgentSettings agentSettings)

--- a/VmAgent.Core/Interfaces/DockerContainerEngine.cs
+++ b/VmAgent.Core/Interfaces/DockerContainerEngine.cs
@@ -412,6 +412,11 @@ namespace Microsoft.Azure.Gaming.VmAgent.ContainerEngines
 
         public static string GetImageNameFromContainerImageDetails(ContainerImageDetails imageDetails)
         {
+            if (imageDetails == null)
+            {
+                throw new ArgumentNullException(nameof(imageDetails));
+            }
+
             string imageName;
             if (!string.IsNullOrEmpty(imageDetails.ImageDigest))
             {


### PR DESCRIPTION
Currently we pull container images by name:tag. This PR adds support to pull container images by name@digest. This is necessary for the ACR consolidation work