### PR TITLE
made PF_SHARED_CONTENT_FOLDER available to vm startup scripts

### DIFF
--- a/VmAgent.Core.UnitTests/VmConfigurationTests.cs
+++ b/VmAgent.Core.UnitTests/VmConfigurationTests.cs
@@ -43,6 +43,28 @@ namespace VmAgent.Core.UnitTests
 
         [TestMethod]
         [TestCategory("BVT")]
+        public void GameSharedContentFolderWithProcess()
+        {
+            SessionHostsStartInfo sessionHostsStartInfo = CreateSessionHostStartInfo(sessionHostType: SessionHostType.Process);
+            IDictionary<string, string> envVariables = VmConfiguration.GetCommonEnvironmentVariables(sessionHostsStartInfo, VmConfiguration);
+            ValidateCommonEnvironmentVariables(envVariables, sessionHostsStartInfo);
+
+            Assert.AreEqual(VmConfiguration.VmDirectories.GameSharedContentFolderVm, envVariables[VmConfiguration.SharedContentFolderEnvVariable]);
+        }
+
+        [TestMethod]
+        [TestCategory("BVT")]
+        public void GameSharedContentFolderWithContainer()
+        {
+            SessionHostsStartInfo sessionHostsStartInfo = CreateSessionHostStartInfo(sessionHostType: SessionHostType.Container);
+            IDictionary<string, string> envVariables = VmConfiguration.GetCommonEnvironmentVariables(sessionHostsStartInfo, VmConfiguration);
+            ValidateCommonEnvironmentVariables(envVariables, sessionHostsStartInfo);
+
+            Assert.AreEqual(VmConfiguration.VmDirectories.GameSharedContentFolderContainer, envVariables[VmConfiguration.SharedContentFolderEnvVariable]);
+        }
+
+        [TestMethod]
+        [TestCategory("BVT")]
         public void VmStartupScriptEnvVariablesWithBuildMetadata()
         {
             var metadata = new Dictionary<string, string>() { { "key1", "value1" }, { "key2", "value2" } };
@@ -51,11 +73,14 @@ namespace VmAgent.Core.UnitTests
             ValidateVmScriptEnvironmentVariables(envVariables, sessionHostsStartInfo);
         }
 
-        private SessionHostsStartInfo CreateSessionHostStartInfo(IDictionary<string, string> buildMetadata = null)
+        private SessionHostsStartInfo CreateSessionHostStartInfo(IDictionary<string, string> buildMetadata = null, SessionHostType sessionHostType = SessionHostType.Process)
         {
             return new SessionHostsStartInfo
             {
-                AssignmentId = CreateAssignmentId(), DeploymentMetadata = buildMetadata, PublicIpV4Address = "42.42.42.42."
+                AssignmentId = CreateAssignmentId(),
+                DeploymentMetadata = buildMetadata,
+                PublicIpV4Address = "42.42.42.42.",
+                SessionHostType = sessionHostType
             };
         }
 

--- a/VmAgent.Core/Interfaces/SessionHostConfigurationBase.cs
+++ b/VmAgent.Core/Interfaces/SessionHostConfigurationBase.cs
@@ -18,9 +18,6 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
     {
         // The server instance number (1 to NumSessionsPerVm) for this session host.
         private const string ServerInstanceNumberEnvVariable = "PF_SERVER_INSTANCE_NUMBER";
-        
-        // Used by the games to share  user generated content (and other files that are downloaded once, used multiple times).
-        private const string SharedContentFolderEnvVariable = "PF_SHARED_CONTENT_FOLDER";
 
         // Used by the GSDK to find the configuration file
         private const string ConfigFileEnvVariable = "GSDK_CONFIG_FILE";
@@ -55,8 +52,6 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
 
         protected abstract string GetCertificatesPath(string assignmentId);
 
-        protected abstract string GetSharedContentFolderPath();
-
         protected SessionHostConfigurationBase(VmConfiguration vmConfiguration, MultiLogger logger, ISystemOperations systemOperations, SessionHostsStartInfo sessionHostsStartInfo)
         {
             _logger = logger;
@@ -78,9 +73,6 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
                 },
                 {
                     LogsDirectoryEnvVariable, GetLogFolder(logFolderId, VmConfiguration)
-                },
-                {
-                    SharedContentFolderEnvVariable, GetSharedContentFolderPath()
                 },
                 {
                     CertificateFolderEnvVariable, GetCertificatesPath(_sessionHostsStartInfo.AssignmentId)

--- a/VmAgent.Core/Interfaces/SessionHostContainerConfiguration.cs
+++ b/VmAgent.Core/Interfaces/SessionHostContainerConfiguration.cs
@@ -45,11 +45,6 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
             return VmConfiguration.VmDirectories.CertificateRootFolderContainer;
         }
 
-        protected override string GetSharedContentFolderPath()
-        {
-            return VmConfiguration.VmDirectories.GameSharedContentFolderContainer;
-        }
-
         protected override string GetLogFolder(string logFolderId, VmConfiguration vmConfiguration)
         {
             // The VM host folder corresponding to the logFolderId gets mounted under this path for each container.

--- a/VmAgent.Core/Interfaces/SessionHostProcessConfiguration.cs
+++ b/VmAgent.Core/Interfaces/SessionHostProcessConfiguration.cs
@@ -28,11 +28,6 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
             return VmConfiguration.VmDirectories.CertificateRootFolderVm;
         }
 
-        protected override string GetSharedContentFolderPath()
-        {
-            return VmConfiguration.VmDirectories.GameSharedContentFolderVm;
-        }
-
         protected override string GetLogFolder(string logFolderId, VmConfiguration vmConfiguration)
         {
             return Path.Combine(vmConfiguration.VmDirectories.GameLogsRootFolderVm, logFolderId);

--- a/VmAgent.Core/VmConfiguration.cs
+++ b/VmAgent.Core/VmConfiguration.cs
@@ -39,14 +39,17 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core
 
         // Used by the games to share user generated content (and other files that are downloaded once, used multiple times).
         // This points to the folder on the VM, and should only be used by VM-level scripts. Game servers
-        // should use `PF_SHARED_CONTENT_FOLDER` instead (which points to wherever the folder is mounted in the container)
+        // should use `PF_SHARED_CONTENT_FOLDER` instead.
         public const string SharedContentFolderVmVariable = "PF_SHARED_CONTENT_FOLDER_VM";
 
         // Used by the games to share user generated content (and other files that are downloaded once, used multiple times).
-        // Also available to VM-level scripts for special cases (e.g. Watson needs to set the Kernel core dump path to this path
-        // so that container-based servers place their dump files in the path available to the container)
-        private const string SharedContentFolderEnvVariable = "PF_SHARED_CONTENT_FOLDER";
-
+        // This is the variable that points to the shared content folder as seen by the game server.
+        // Because of this, it is the same as PF_SHARED_CONTENT_FOLDER_VM if the server is process-based and it is different if
+        // the server is container-based.
+        // Typically this wouldn't be needed by VM startup scripts (since it might point to a path that only exists inside a container)
+        // but the Watson team found an edge case where the VM needs access to it so we made it available to the VM startup scripts as well.
+        public const string SharedContentFolderEnvVariable = "PF_SHARED_CONTENT_FOLDER";
+        
         private static readonly byte[] PlayFabTitleIdPrefix = BitConverter.GetBytes(0xFFFFFFFFFFFFFFFF);
 
         public int ListeningPort { get; }


### PR DESCRIPTION
This fix is specifically for the Watson team. Previously we gave their startup script the PF_SHARED_CONTENT_FOLDER_VM variable so that their agent process knows where to find crash dumps, but it turns out their script also needs the PF_SHARED_CONTENT_FOLDER variable so that they can set the linux kernel core path correctly for container-based servers to place their dumps in the shared content folder.

So for example:
PF_SHARED_CONTENT_FOLDER_VM = /mnt/GameSharedContent <- this folder exists on the VM
PF_SHARED_CONTENT_FOLDER (on a process based server) = /mnt/GameSharedContent
PF_SHARED_CONTENT_FOLDER (on a container based server) = /data/GameSharedContent <- this folder exists only exists inside a container, and is where PF_SHARED_CONTENT_FOLDER_VM is mounted
Their startup script tells the Watson agent to look for crash dumps in PF_SHARED_CONTENT_FOLDER_VM. The linux kernel core path tells linux where to place crash dumps, so they set it to PF_SHARED_CONTENT_FOLDER_VM. Turns out this doesn't work for containers--when a process in a container crashed, it tried placing the crash dump into /mnt/GameSharedContent which is a path that doesn't exist inside the container.
But they can get it to work if they set the linux kernel core path to PF_SHARED_CONTENT_FOLDER--that way when a process inside a container crashed, it got placed in /data/GameSharedContent (which is mounted to /mnt/GameSharedContent like we want). And for process based servers PF_SHARED_CONTENT_FOLDER is set to /mnt/GameSharedContent like we want. 

tl;dr PF_SHARED_CONTENT_FOLDER_VM is the true path to the shared content folder on the VM, while PF_SHARED_CONTENT_FOLDER is the path where a server *thinks* the shared content folder is. Turns out both are useful for VM startup scripts to have