### PR TITLE
upgrading Newtonsoft

### DIFF
--- a/AgentInterfaces/AgentInterfaces.csproj
+++ b/AgentInterfaces/AgentInterfaces.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Docker.DotNet" Version="3.125.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>

--- a/VmAgent.Core/VmAgent.Core.csproj
+++ b/VmAgent.Core/VmAgent.Core.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Docker.DotNet" Version="3.125.4" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="Polly" Version="7.1.1" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.7.0" />
   </ItemGroup>


### PR DESCRIPTION
upgrading Newtonsoft.Json.Net to 13.0.2 because of a security vulnerability. 