### PR TITLE
Fix certificate folder in gsdk config for Process based servers.

### DIFF
--- a/VmAgent.Core/Interfaces/SessionHostConfigurationBase.cs
+++ b/VmAgent.Core/Interfaces/SessionHostConfigurationBase.cs
@@ -48,9 +48,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
 
         protected readonly SessionHostsStartInfo _sessionHostsStartInfo;
 
-        protected abstract string GetGsdkConfigFilePath(string assignmentId, int instanceNumber);
-
-        protected abstract string GetCertificatesPath(string assignmentId);
+        protected abstract string GetGsdkConfigFilePath(int instanceNumber);
 
         protected SessionHostConfigurationBase(VmConfiguration vmConfiguration, MultiLogger logger, ISystemOperations systemOperations, SessionHostsStartInfo sessionHostsStartInfo)
         {
@@ -66,19 +64,19 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
             var environmentVariables = new Dictionary<string, string>()
             {
                 {
-                    ConfigFileEnvVariable, GetGsdkConfigFilePath(_sessionHostsStartInfo.AssignmentId, instanceNumber)
+                    ConfigFileEnvVariable, GetGsdkConfigFilePath(instanceNumber)
                 },
                 {
                     ServerInstanceNumberEnvVariable, instanceNumber.ToString()
                 },
                 {
-                    LogsDirectoryEnvVariable, GetLogFolder(logFolderId, VmConfiguration)
+                    LogsDirectoryEnvVariable, GetLogFolder(logFolderId)
                 },
                 {
-                    CertificateFolderEnvVariable, GetCertificatesPath(_sessionHostsStartInfo.AssignmentId)
+                    CertificateFolderEnvVariable, GetCertificateFolder()
                 },
                 {
-                    DumpsDirectoryEnvVariable, GetDumpFolder(logFolderId, VmConfiguration)
+                    DumpsDirectoryEnvVariable, GetDumpFolder(logFolderId)
                 }
             };
 
@@ -112,9 +110,9 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
                 HeartbeatEndpoint = $"{agentEndpoint}:{VmConfiguration.ListeningPort}",
                 SessionHostId = sessionHostUniqueId,
                 VmId = vmConfiguration.VmId,
-                LogFolder = GetLogFolder(logFolderId, vmConfiguration),
-                CertificateFolder = vmConfiguration.VmDirectories.CertificateRootFolderContainer,
-                SharedContentFolder = vmConfiguration.VmDirectories.GameSharedContentFolderContainer,
+                LogFolder = GetLogFolder(logFolderId),
+                CertificateFolder = GetCertificateFolder(),
+                SharedContentFolder = GetSharedContentFolder(),
                 GameCertificates = certThumbprints,
                 BuildMetadata = _sessionHostsStartInfo.DeploymentMetadata,
                 GamePorts = portMappings,
@@ -130,16 +128,16 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
             _systemOperations.FileWriteAllText(configFilePath, outputJson);
         }
 
-        protected abstract string GetLogFolder(string logFolderId, VmConfiguration vmConfiguration);
+        protected abstract string GetLogFolder(string logFolderId);
 
-        protected string GetDumpFolder(string logFolderId, VmConfiguration vmConfiguration)
+        protected string GetDumpFolder(string logFolderId)
         {
-            return Path.Combine(GetLogFolder(logFolderId, vmConfiguration), VmDirectories.GameDumpsFolderName);
+            return Path.Combine(GetLogFolder(logFolderId), VmDirectories.GameDumpsFolderName);
         }
 
-        protected abstract string GetSharedContentFolder(VmConfiguration vmConfiguration);
+        protected abstract string GetSharedContentFolder();
 
-        protected abstract string GetCertificateFolder(VmConfiguration vmConfiguration);
+        protected abstract string GetCertificateFolder();
 
         private void CreateLegacyGSDKConfigFile(int instanceNumber, string sessionHostUniqueId, Dictionary<string, string> certThumbprints, IDictionary<string, string> portMappings)
         {

--- a/VmAgent.Core/Interfaces/SessionHostContainerConfiguration.cs
+++ b/VmAgent.Core/Interfaces/SessionHostContainerConfiguration.cs
@@ -35,38 +35,33 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
             _shouldPublicPortMatchGamePort = shouldPublicPortMatchGamePort;
         }
         
-        protected override string GetGsdkConfigFilePath(string assignmentId, int instanceNumber)
+        protected override string GetGsdkConfigFilePath(int instanceNumber)
         {
             return VmConfiguration.VmDirectories.GsdkConfigFilePathContainer;
         }
 
-        protected override string GetCertificatesPath(string assignmentId)
-        {
-            return VmConfiguration.VmDirectories.CertificateRootFolderContainer;
-        }
-
-        protected override string GetLogFolder(string logFolderId, VmConfiguration vmConfiguration)
+        protected override string GetLogFolder(string logFolderId)
         {
             // The VM host folder corresponding to the logFolderId gets mounted under this path for each container.
             // So the logFolderId itself isn't of much significance within the container.
             if (_isRunningLinuxContainersOnWindows)
             {
-                return vmConfiguration.VmDirectories.GameLogsRootFolderContainer + Path.AltDirectorySeparatorChar;
+                return VmConfiguration.VmDirectories.GameLogsRootFolderContainer + Path.AltDirectorySeparatorChar;
             }
             else
             {
-                return vmConfiguration.VmDirectories.GameLogsRootFolderContainer + Path.DirectorySeparatorChar;
+                return VmConfiguration.VmDirectories.GameLogsRootFolderContainer + Path.DirectorySeparatorChar;
             }
         }
 
-        protected override string GetSharedContentFolder(VmConfiguration vmConfiguration)
+        protected override string GetSharedContentFolder()
         {
-            return vmConfiguration.VmDirectories.GameSharedContentFolderContainer;
+            return VmConfiguration.VmDirectories.GameSharedContentFolderContainer;
         }
 
-        protected override string GetCertificateFolder(VmConfiguration vmConfiguration)
+        protected override string GetCertificateFolder()
         {
-            return vmConfiguration.VmDirectories.CertificateRootFolderContainer;
+            return VmConfiguration.VmDirectories.CertificateRootFolderContainer;
         }
 
         /// <summary>

--- a/VmAgent.Core/Interfaces/SessionHostProcessConfiguration.cs
+++ b/VmAgent.Core/Interfaces/SessionHostProcessConfiguration.cs
@@ -16,31 +16,26 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core.Interfaces
         {
         }
 
-        protected override string GetGsdkConfigFilePath(string assignmentId, int instanceNumber)
+        protected override string GetGsdkConfigFilePath(int instanceNumber)
         {
             return Path.Combine(
                 VmConfiguration.GetConfigRootFolderForSessionHost(instanceNumber),
                 VmDirectories.GsdkConfigFilename);
         }
 
-        protected override string GetCertificatesPath(string assignmentId)
+        protected override string GetLogFolder(string logFolderId)
+        {
+            return Path.Combine(VmConfiguration.VmDirectories.GameLogsRootFolderVm, logFolderId);
+        }
+
+        protected override string GetSharedContentFolder()
+        {
+            return VmConfiguration.VmDirectories.GameSharedContentFolderVm;
+        }
+
+        protected override string GetCertificateFolder()
         {
             return VmConfiguration.VmDirectories.CertificateRootFolderVm;
-        }
-
-        protected override string GetLogFolder(string logFolderId, VmConfiguration vmConfiguration)
-        {
-            return Path.Combine(vmConfiguration.VmDirectories.GameLogsRootFolderVm, logFolderId);
-        }
-
-        protected override string GetSharedContentFolder(VmConfiguration vmConfiguration)
-        {
-            return vmConfiguration.VmDirectories.GameSharedContentFolderVm;
-        }
-
-        protected override string GetCertificateFolder(VmConfiguration vmConfiguration)
-        {
-            return vmConfiguration.VmDirectories.CertificateRootFolderVm;
         }
 
         /// <summary>


### PR DESCRIPTION
It appears that the env variables were set correctly for both types of servers but the gsdkConfiguration would always assume the server was running inside a container. This PR fixes that.