### PR TITLE
ordering VmStartupScriptPorts by NodePort

### DIFF
--- a/VmAgent.Core.UnitTests/VmConfigurationTests.cs
+++ b/VmAgent.Core.UnitTests/VmConfigurationTests.cs
@@ -88,6 +88,7 @@ namespace VmAgent.Core.UnitTests
             };
             IDictionary<string, string> envVariables = VmConfiguration.GetEnvironmentVariablesForVmStartupScripts(sessionHostsStartInfo, VmConfiguration);
             ValidateVmScriptEnvironmentVariables(envVariables, sessionHostsStartInfo);
+            envVariables.Should().Contain("PF_STARTUP_SCRIPT_PORT_COUNT", "2");
             for (int i = 0; i < 2; i++)
             {
                 envVariables.Should().Contain($"PF_STARTUP_SCRIPT_PORT_NAME_{i}", $"port{i}");

--- a/VmAgent.Core/VmConfiguration.cs
+++ b/VmAgent.Core/VmConfiguration.cs
@@ -150,8 +150,9 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core
 
             if (sessionHostsStartInfo.VmStartupScriptConfiguration?.Ports != null)
             {
+                // order them by NodePort (VmPort) so that the lowest port is always the first one
                 int index = 0;
-                foreach (VmStartupScriptPort port in sessionHostsStartInfo.VmStartupScriptConfiguration.Ports)
+                foreach (VmStartupScriptPort port in sessionHostsStartInfo.VmStartupScriptConfiguration.Ports.OrderBy(x => x.NodePort))
                 {
                     environmentVariables.Add($"PF_STARTUP_SCRIPT_PORT_NAME_{index}", port.Name);
                     environmentVariables.Add($"PF_STARTUP_SCRIPT_PORT_EXTERNAL_{index}", port.PublicPort.ToString());

--- a/VmAgent.Core/VmConfiguration.cs
+++ b/VmAgent.Core/VmConfiguration.cs
@@ -150,6 +150,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core
 
             if (sessionHostsStartInfo.VmStartupScriptConfiguration?.Ports != null)
             {
+                environmentVariables.Add($"PF_STARTUP_SCRIPT_PORT_COUNT", sessionHostsStartInfo.VmStartupScriptConfiguration?.Ports.Count().ToString());
                 // order them by NodePort (VmPort) so that the lowest port is always the first one
                 int index = 0;
                 foreach (VmStartupScriptPort port in sessionHostsStartInfo.VmStartupScriptConfiguration.Ports.OrderBy(x => x.NodePort))


### PR DESCRIPTION
This PR orders the VmStartupScriptPorts by NodePort (VmPort) before assigning them to the VmStartupScript as environment variables. This is to make sure that the lower the index, the lower the VmPort.

Moreover, it adds an environment variable with the total ports count, so the user can easily create loops to grab all VmStartupScript port environment variables.