### PR TITLE
unify GetImageNameAndTagFromContainerImageDetails

### DIFF
--- a/VmAgent.Core.UnitTests/DockerContainerEngineTests.cs
+++ b/VmAgent.Core.UnitTests/DockerContainerEngineTests.cs
@@ -24,27 +24,10 @@ namespace VmAgent.Core.UnitTests
                 ImageDigest = null,
                 Registry = null,
             };
-            Assert.AreEqual("name:tag", DockerContainerEngine.GetImageNameFromContainerImageDetails(imageDetails));
+            Assert.AreEqual("name:tag", DockerContainerEngine.GetImageNameAndTagFromContainerImageDetails(imageDetails));
 
             imageDetails.Registry = "registry";
-            Assert.AreEqual("registry/name:tag", DockerContainerEngine.GetImageNameFromContainerImageDetails(imageDetails));
-        }
-
-        [TestMethod]
-        [TestCategory("BVT")]
-        public void TestGetImageNameWithDigest()
-        {
-            var imageDetails = new ContainerImageDetails
-            {
-                ImageName = "name",
-                ImageTag = "tag",
-                ImageDigest = "digest",
-                Registry = null,
-            };
-            Assert.AreEqual("name@digest", DockerContainerEngine.GetImageNameFromContainerImageDetails(imageDetails));
-
-            imageDetails.Registry = "registry";
-            Assert.AreEqual("registry/name@digest", DockerContainerEngine.GetImageNameFromContainerImageDetails(imageDetails));
+            Assert.AreEqual("registry/name:tag", DockerContainerEngine.GetImageNameAndTagFromContainerImageDetails(imageDetails));
         }
     }
 }

--- a/VmAgent.Core/Interfaces/DockerContainerEngine.cs
+++ b/VmAgent.Core/Interfaces/DockerContainerEngine.cs
@@ -415,7 +415,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.ContainerEngines
             return sessionHost;
         }
 
-        public static string GetImageNameFromContainerImageDetails(ContainerImageDetails imageDetails)
+        private static string GetImageNameFromContainerImageDetails(ContainerImageDetails imageDetails)
         {
             if (imageDetails == null)
             {
@@ -433,7 +433,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.ContainerEngines
             return imageName;
         }
 
-        public static string GetTagFromContainerImageDetails(ContainerImageDetails imageDetails)
+        private static string GetTagFromContainerImageDetails(ContainerImageDetails imageDetails)
         {
             if (imageDetails == null)
             {


### PR DESCRIPTION
A while back i added logic to pull images using the image Digest instead of the image Tag. Turns out i messed up--we had duplicate code in two places and i only changed one of them.
There are two places we need to specify an Tag/Digest:
1) when we pull the image from the remote registry
2) when we create a container using an image that we've already pulled

I only updated the 2nd place. So right now we are continuing to pull images from the remote registry using their tag, and then we use their digest to create containers with them. This works because the image referenced by the tag should also have the digest that we expect. But this opens us up to issues where the image referenced by a tag DOESN'T have the digest that we expect--in that case, we pull image with tag A and then try to create a container with Digest B and can't find the image that we pulled.

In practice this should never happen, but i'm unifying the logic so that now everywhere uses the same logic for identifying what image to use: `GetImageNameAndTagFromContainerImageDetails()`.

Also, using the digest isn't necessary anymore--i did that as part of the consolidatedAcr work and it ended up not being necessary.