### PR TITLE
Remove innecessary PublicIpv4Addresses property in SessionHost

### DIFF
--- a/AgentInterfaces/SessionHost.cs
+++ b/AgentInterfaces/SessionHost.cs
@@ -85,14 +85,8 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
         public string SecureDeviceAddress { get; set; }
 
         /// <summary>
-        /// TODO: Remove this once the other IPV4 version is used
         /// List of All Public IP Addresses working with the session
         /// </summary>
         public List<PublicIpAddress> PublicIpAddresses { get; set; }
-
-        /// <summary>
-        /// List of Public IPv4 Addresses working with the session
-        /// </summary>
-        public List<PublicIpAddress> PublicIpv4Addresses { get; set; }
     }
 }


### PR DESCRIPTION
The PublicIpv4Addresses is not necessary at this stage. It can be managed added at API response level filtering with the IpVersion Property in PublicIpAddress object.