### PR TITLE
Remove Geneva Agent Channel Logger

### DIFF
--- a/LocalMultiplayerAgent/Globals.cs
+++ b/LocalMultiplayerAgent/Globals.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Gaming.LocalMultiplayerAgent
             .CreateLogger("PlayFabLocalMultiplayerAgent");
 
         public static MultiLogger MultiLogger =
-            new MultiLogger(Logger, new TelemetryClient(TelemetryConfiguration.CreateDefault()));
+            new MultiLogger(Logger);
 
         public static GameServerEnvironment GameServerEnvironment { get; set; }
     }

--- a/VmAgent.Core.UnitTests/BasicAssetExtractorTest.cs
+++ b/VmAgent.Core.UnitTests/BasicAssetExtractorTest.cs
@@ -38,7 +38,7 @@ namespace VmAgent.Core.UnitTests
         [TestInitialize]
         public void BeforeEachTest()
         {
-            _multiLogger = new MultiLogger(NullLogger.Instance, new TelemetryClient(TelemetryConfiguration.CreateDefault()));      
+            _multiLogger = new MultiLogger(NullLogger.Instance);      
             _mockSystemOperations = new Mock<ISystemOperations>();
             _basicAssetExtractor = new BasicAssetExtractor(_mockSystemOperations.Object, _multiLogger);
         }

--- a/VmAgent.Core.UnitTests/ProcessOutputLoggerTest.cs
+++ b/VmAgent.Core.UnitTests/ProcessOutputLoggerTest.cs
@@ -24,7 +24,7 @@ namespace VmAgent.Core.UnitTests
         [TestInitialize]
         public void BeforeEachTest()
         {
-            _multiLogger = new MultiLogger(NullLogger.Instance, new TelemetryClient(TelemetryConfiguration.CreateDefault()));
+            _multiLogger = new MultiLogger(NullLogger.Instance);
             _fileWriteWrapper = new Mock<IFileWriteWrapper>();
 
             Mock<ProcessOutputLogger> mockProcessLogger = new Mock<ProcessOutputLogger>(

--- a/VmAgent.Core.UnitTests/SessionHostConfigurationTests.cs
+++ b/VmAgent.Core.UnitTests/SessionHostConfigurationTests.cs
@@ -54,7 +54,7 @@ namespace VmAgent.Core.UnitTests
         {
             string AssignmentId = $"{TestTitleIdUlong}:{TestBuildId}:{TestRegion}";
 
-            _logger = new MultiLogger(NullLogger.Instance, new TelemetryClient(TelemetryConfiguration.CreateDefault()));
+            _logger = new MultiLogger(NullLogger.Instance);
             _systemOperations = new Mock<ISystemOperations>();
             _dockerClient = new Mock<IDockerClient>();
             _sessionHostManager = new Mock<ISessionHostManager>();

--- a/VmAgent.Core.UnitTests/SystemOperationsTests.cs
+++ b/VmAgent.Core.UnitTests/SystemOperationsTests.cs
@@ -51,7 +51,7 @@ namespace VmAgent.Core.UnitTests
 
             _mockFileSystemOperations = new Mock<IFileSystemOperations>();
             _vmConfiguration = new VmConfiguration(56001, "vmid", new VmDirectories("root"), true);
-            _logger = new MultiLogger(NullLogger.Instance, new TelemetryClient(TelemetryConfiguration.CreateDefault()));
+            _logger = new MultiLogger(NullLogger.Instance);
             _systemOperations = new SystemOperations(_vmConfiguration, _logger, _mockFileSystemOperations.Object);
 
             _mockFileSystemOperations.Setup(x => x.IsDirectory(_root)).Returns(true);

--- a/VmAgent.Core/MultiLogger.cs
+++ b/VmAgent.Core/MultiLogger.cs
@@ -25,10 +25,10 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core
         public void LogVerbose(string message)
         {
             _logger.LogInformation(message);
-			_genevaOtelLogger?.LogInformation(message);
-		}
+            _genevaOtelLogger?.LogInformation(message);
+        }
 
-		public void LogInformation(string message)
+        public void LogInformation(string message)
         {
             _logger.LogInformation(message);
             _genevaOtelLogger?.LogInformation(message);


### PR DESCRIPTION
Now that we verified the logs both from Geneva Agent Channel and OpenTelemetry, replace GenevaAgentchannel with OpenTelemetry Logger.