### PR TITLE
fixing InitialPlayers bug

### DIFF
--- a/LocalMultiplayerAgent/Program.cs
+++ b/LocalMultiplayerAgent/Program.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.Gaming.LocalMultiplayerAgent
             Console.WriteLine($"Local Multiplayer Agent is listening on port {settings.AgentListeningPort}");
 
             Globals.SessionConfig = settings.SessionConfig ?? new SessionConfig() { SessionId = Guid.NewGuid() };
-            if(Globals.SessionConfig.InitialPlayers != null)
+            if (Globals.SessionConfig.InitialPlayers != null)
             {
                 Console.WriteLine($"{string.Join(", ", Globals.SessionConfig.InitialPlayers)}");
             }

--- a/LocalMultiplayerAgent/Program.cs
+++ b/LocalMultiplayerAgent/Program.cs
@@ -94,7 +94,10 @@ namespace Microsoft.Azure.Gaming.LocalMultiplayerAgent
             Console.WriteLine($"Local Multiplayer Agent is listening on port {settings.AgentListeningPort}");
 
             Globals.SessionConfig = settings.SessionConfig ?? new SessionConfig() { SessionId = Guid.NewGuid() };
-            Console.WriteLine($"{string.Join(", ", Globals.SessionConfig.InitialPlayers)}");
+            if(Globals.SessionConfig.InitialPlayers != null)
+            {
+                Console.WriteLine($"{string.Join(", ", Globals.SessionConfig.InitialPlayers)}");
+            }
             await new MultiplayerServerManager(SystemOperations.Default, Globals.VmConfiguration, Globals.MultiLogger, SessionHostRunnerFactory.Instance)
                 .CreateAndStartContainerWaitForExit(settings.ToSessionHostsStartInfo());
 


### PR DESCRIPTION
If developer doesn't provide a InitialPlayers dictionary, LMA crashes on start. This PR mitigates the issue.

Originally reported on Discord on https://discord.com/channels/684463257276121192/789588870877413386/1151262936497664051