### PR TITLE
added PortMappings to VmAgentInfo

### DIFF
--- a/AgentInterfaces.Tests/VmAgentInfoTests.cs
+++ b/AgentInterfaces.Tests/VmAgentInfoTests.cs
@@ -49,6 +49,7 @@ namespace AgentInterfaces.Tests
                 nameof(VmAgentInfo.AssignmentId),
                 nameof(VmAgentInfo.SequenceNumber),
                 nameof(VmAgentInfo.IsUnassignable),
+                nameof(VmAgentInfo.PortMappings),
                 nameof(VmAgentInfo.NetworkConfiguration),
                 nameof(VmAgentInfo.VmMonitoringOutputId),
                 nameof(VmAgentInfo.ToSViolationRating)

--- a/AgentInterfaces/VmAgentInfo.cs
+++ b/AgentInterfaces/VmAgentInfo.cs
@@ -33,6 +33,11 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
         public bool? IsUnassignable { get; set; }
 
         /// <summary>
+        /// Port mappings at the vm level for VmStartupScript
+        /// </summary>
+        public List<PortMapping> PortMappings { get; set; }
+
+        /// <summary>
         /// The network configuration of the agent, describing the endpoints available on the VM.
         /// </summary>
         public VmNetworkConfiguration NetworkConfiguration { get; set; }
@@ -51,8 +56,9 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
                 string maintenanceSchedule = MaintenanceSchedule?.ToJsonString() ?? string.Empty;
                 string networkConfiguration = NetworkConfiguration?.ToJsonString() ?? string.Empty;
                 string sessionHostSummary = SessionHostHeartbeatMap.Values.GroupBy(x => x.CurrentGameState).ToDictionary(y => y.Key, y => y.Count()).ToJsonString();
+                string portMappings = PortMappings?.ToJsonString() ?? string.Empty;
                 return
-                    $"VmState: {VmState}, AssignmentId: {AssignmentId ?? string.Empty}, AgentProcessGuid : {AgentProcessGuid}, SequenceNumber {SequenceNumber}, MaintenanceSchedule : {maintenanceSchedule}, IsUnassignable: {IsUnassignable ?? false}, NetworkConfiguration: {networkConfiguration}, SessionHostSummary: {sessionHostSummary}, VmMonitoringOutput: {VmMonitoringOutputId}, ToSViolationRating: {ToSViolationRating}";
+                    $"VmState: {VmState}, AssignmentId: {AssignmentId ?? string.Empty}, AgentProcessGuid : {AgentProcessGuid}, SequenceNumber {SequenceNumber}, MaintenanceSchedule : {maintenanceSchedule}, IsUnassignable: {IsUnassignable ?? false}, PortMappings: {portMappings}, NetworkConfiguration: {networkConfiguration}, SessionHostSummary: {sessionHostSummary}, VmMonitoringOutput: {VmMonitoringOutputId}, ToSViolationRating: {ToSViolationRating}";
             }
 
             return this.ToJsonString();


### PR DESCRIPTION
Added PortMappings to VmAgentInfo so that VmAgent can send vmStartupScript ports to ControlPlane in its heartbeats.

`PortMapping` is the same class that SessionHostInfo uses to start its ports--it has an external port, an internal port, the user-specified name, and the protocol (tcp/udp).

I named the field "PortMappings", which is also the same name that SessionHostInfo uses. It should be fine since they are nested at different levels. A VmAgent heartbeat will look like this (with all the other fields removed):
```json
{
    "SessionHostHeartbeatMap": {
        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa": {
            "PortMappings": [
                {
                    "PublicPort": 30001,
                    "NodePort": 30000,
                    "GamePort": {
                        "Name": "game",
                        "Protocol": "TCP"
                    }
                }
            ]
        }
    },
    "PortMappings": [
        {
            "PublicPort": 20001,
            "NodePort": 20001,
            "GamePort": {
                "Name": "pix",
                "Protocol": "TCP"
            }
        }
    ]
}
````
