### PR TITLE
VmAgent endpoint to report GSDK version telemetry

### DIFF
--- a/LocalMultiplayerAgent/Instrumentation/GsdkVersionInfo.cs
+++ b/LocalMultiplayerAgent/Instrumentation/GsdkVersionInfo.cs
@@ -1,0 +1,8 @@
+﻿namespace LocalMultiplayerAgent.Instrumentation
+{
+    public class GsdkVersionInfo
+    {
+        public string Flavor { get; set; } // Unreal/Unity/C#/C++ etc.
+        public string Version { get; set; }
+    }
+}


### PR DESCRIPTION
This PR creates an extra endpoint on VmAgent HTTP server to accept environment/version info from GSDK. Implementation is pretty simple since VmAgent will just log the version.