### PR TITLE
add configurable maintenance event to local agent

### DIFF
--- a/AgentInterfaces.Tests/MaintenanceScheduleTests.cs
+++ b/AgentInterfaces.Tests/MaintenanceScheduleTests.cs
@@ -19,7 +19,7 @@ namespace AgentInterfaces.Tests
             MaintenanceSchedule schedule = JsonConvert.DeserializeObject<MaintenanceSchedule>(payload);
             Assert.AreEqual("1", schedule.DocumentIncarnation);
             Assert.AreEqual(1, schedule.MaintenanceEvents.Count);
-            Assert.AreEqual(1, schedule.MaintenanceEvents[0].AffectedResources.Count);
+            Assert.AreEqual(1, schedule.MaintenanceEvents[0].Resources.Count);
             Assert.AreEqual(10, schedule.MaintenanceEvents[0].DurationInSeconds);
             AssertNonNullProperties(schedule);
         }
@@ -32,7 +32,7 @@ namespace AgentInterfaces.Tests
             MaintenanceSchedule schedule = JsonConvert.DeserializeObject<MaintenanceSchedule>(payload);
             Assert.AreEqual("1", schedule.DocumentIncarnation);
             Assert.AreEqual(2, schedule.MaintenanceEvents.Count);
-            Assert.AreEqual(1, schedule.MaintenanceEvents[0].AffectedResources.Count);
+            Assert.AreEqual(1, schedule.MaintenanceEvents[0].Resources.Count);
             Assert.AreEqual(9, schedule.MaintenanceEvents[0].DurationInSeconds);
             Assert.AreEqual(-1, schedule.MaintenanceEvents[1].DurationInSeconds);
             AssertNonNullProperties(schedule);
@@ -50,13 +50,13 @@ namespace AgentInterfaces.Tests
 
         [TestMethod]
         [TestCategory("BVT")]
-        public void TestParseSingleMaintenanceEventMultipleAffectedResources()
+        public void TestParseSingleMaintenanceEventMultipleResources()
         {
-            string payload = File.ReadAllText("SingleMaintenanceEventMultipleAffectedResources.json");
+            string payload = File.ReadAllText("SingleMaintenanceEventMultipleResources.json");
             MaintenanceSchedule schedule = JsonConvert.DeserializeObject<MaintenanceSchedule>(payload);
             Assert.AreEqual("1", schedule.DocumentIncarnation);
             Assert.AreEqual(1, schedule.MaintenanceEvents.Count);
-            Assert.AreEqual(2, schedule.MaintenanceEvents[0].AffectedResources.Count);
+            Assert.AreEqual(2, schedule.MaintenanceEvents[0].Resources.Count);
             AssertNonNullProperties(schedule);
         }
 

--- a/AgentInterfaces.Tests/MaintenanceScheduleTests.cs
+++ b/AgentInterfaces.Tests/MaintenanceScheduleTests.cs
@@ -19,7 +19,7 @@ namespace AgentInterfaces.Tests
             MaintenanceSchedule schedule = JsonConvert.DeserializeObject<MaintenanceSchedule>(payload);
             Assert.AreEqual("1", schedule.DocumentIncarnation);
             Assert.AreEqual(1, schedule.MaintenanceEvents.Count);
-            Assert.AreEqual(1, schedule.MaintenanceEvents[0].Resources.Count);
+            Assert.AreEqual(1, schedule.MaintenanceEvents[0].AffectedResources.Count);
             Assert.AreEqual(10, schedule.MaintenanceEvents[0].DurationInSeconds);
             AssertNonNullProperties(schedule);
         }
@@ -32,7 +32,7 @@ namespace AgentInterfaces.Tests
             MaintenanceSchedule schedule = JsonConvert.DeserializeObject<MaintenanceSchedule>(payload);
             Assert.AreEqual("1", schedule.DocumentIncarnation);
             Assert.AreEqual(2, schedule.MaintenanceEvents.Count);
-            Assert.AreEqual(1, schedule.MaintenanceEvents[0].Resources.Count);
+            Assert.AreEqual(1, schedule.MaintenanceEvents[0].AffectedResources.Count);
             Assert.AreEqual(9, schedule.MaintenanceEvents[0].DurationInSeconds);
             Assert.AreEqual(-1, schedule.MaintenanceEvents[1].DurationInSeconds);
             AssertNonNullProperties(schedule);
@@ -50,13 +50,13 @@ namespace AgentInterfaces.Tests
 
         [TestMethod]
         [TestCategory("BVT")]
-        public void TestParseSingleMaintenanceEventMultipleResources()
+        public void TestParseSingleMaintenanceEventMultipleAffectedResources()
         {
-            string payload = File.ReadAllText("SingleMaintenanceEventMultipleResources.json");
+            string payload = File.ReadAllText("SingleMaintenanceEventMultipleAffectedResources.json");
             MaintenanceSchedule schedule = JsonConvert.DeserializeObject<MaintenanceSchedule>(payload);
             Assert.AreEqual("1", schedule.DocumentIncarnation);
             Assert.AreEqual(1, schedule.MaintenanceEvents.Count);
-            Assert.AreEqual(2, schedule.MaintenanceEvents[0].Resources.Count);
+            Assert.AreEqual(2, schedule.MaintenanceEvents[0].AffectedResources.Count);
             AssertNonNullProperties(schedule);
         }
 

--- a/AgentInterfaces/MaintenanceSchedule.cs
+++ b/AgentInterfaces/MaintenanceSchedule.cs
@@ -27,15 +27,6 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
             DocumentIncarnation = other.DocumentIncarnation;
             MaintenanceEvents = other.MaintenanceEvents.Select((e) => new MaintenanceEvent(e)).ToList();
         }
-
-        public MaintenanceSchedule(string eventType, string eventStatus, string eventSource)
-        {
-            DocumentIncarnation = "1";
-            MaintenanceEvents = new List<MaintenanceEvent>()
-            {
-                new MaintenanceEvent(eventType, eventStatus, eventSource)
-            };
-        }
     }
 
     // https://docs.microsoft.com/en-us/azure/virtual-machines/windows/scheduled-events#query-for-events
@@ -48,7 +39,8 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
 
         public string ResourceType { get; set; }
 
-        public IList<string> Resources { get; set; }
+        [JsonProperty("Resources")]
+        public IList<string> AffectedResources { get; set; }
 
         public string EventStatus { get; set; }
 
@@ -70,24 +62,11 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
             EventId = other.EventId;
             EventType = other.EventType;
             ResourceType = other.ResourceType;
-            Resources = other.Resources.ToList();
+            AffectedResources = other.AffectedResources.ToList();
             EventStatus = other.EventStatus;
             NotBefore = other.NotBefore;
             EventSource = other.EventSource;
             DurationInSeconds = other.DurationInSeconds;
-        }
-
-        public MaintenanceEvent(string eventType, string eventStatus, string eventSource)
-        {
-            EventId = Guid.NewGuid().ToString();
-            EventType = eventType;
-            ResourceType = "VirtualMachine";
-            Resources = new List<string>() { "vmId" };
-            EventStatus = eventStatus;
-            NotBefore = DateTime.UtcNow.AddMinutes(5);
-            Description = $"Scheduled {eventType} event for VM";
-            EventSource = eventSource;
-            DurationInSeconds = 300;
         }
     }
 }

--- a/AgentInterfaces/MaintenanceSchedule.cs
+++ b/AgentInterfaces/MaintenanceSchedule.cs
@@ -15,10 +15,7 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
     {
         public string DocumentIncarnation { get; set; }
 
-        [JsonProperty("Events")]
         public IList<MaintenanceEvent> MaintenanceEvents { get; set; }
-
-        public string ReportingVmId { get; set; }
 
         public MaintenanceSchedule() { }
 
@@ -29,7 +26,15 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
         {
             DocumentIncarnation = other.DocumentIncarnation;
             MaintenanceEvents = other.MaintenanceEvents.Select((e) => new MaintenanceEvent(e)).ToList();
-            ReportingVmId = other.ReportingVmId;
+        }
+
+        public MaintenanceSchedule(string eventType, string eventStatus, string eventSource)
+        {
+            DocumentIncarnation = "1";
+            MaintenanceEvents = new List<MaintenanceEvent>()
+            {
+                new MaintenanceEvent(eventType, eventStatus, eventSource)
+            };
         }
     }
 
@@ -43,12 +48,13 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
 
         public string ResourceType { get; set; }
 
-        [JsonProperty("Resources")]
-        public IList<string> AffectedResources { get; set; }
+        public IList<string> Resources { get; set; }
 
         public string EventStatus { get; set; }
 
         public DateTime? NotBefore { get; set; }
+
+        public string Description { get; set; }
 
         public string EventSource { get; set; }
 
@@ -64,11 +70,24 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
             EventId = other.EventId;
             EventType = other.EventType;
             ResourceType = other.ResourceType;
-            AffectedResources = other.AffectedResources.ToList();
+            Resources = other.Resources.ToList();
             EventStatus = other.EventStatus;
             NotBefore = other.NotBefore;
             EventSource = other.EventSource;
             DurationInSeconds = other.DurationInSeconds;
+        }
+
+        public MaintenanceEvent(string eventType, string eventStatus, string eventSource)
+        {
+            EventId = Guid.NewGuid().ToString();
+            EventType = eventType;
+            ResourceType = "VirtualMachine";
+            Resources = new List<string>() { "vmId" };
+            EventStatus = eventStatus;
+            NotBefore = DateTime.UtcNow.AddMinutes(5);
+            Description = $"Scheduled {eventType} event for VM";
+            EventSource = eventSource;
+            DurationInSeconds = 300;
         }
     }
 }

--- a/AgentInterfaces/MaintenanceSchedule.cs
+++ b/AgentInterfaces/MaintenanceSchedule.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
     {
         public string DocumentIncarnation { get; set; }
 
+        [JsonProperty("Events")]
         public IList<MaintenanceEvent> MaintenanceEvents { get; set; }
 
         public MaintenanceSchedule() { }

--- a/AgentInterfaces/MaintenanceSchedule.cs
+++ b/AgentInterfaces/MaintenanceSchedule.cs
@@ -15,8 +15,10 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
     {
         public string DocumentIncarnation { get; set; }
 
-        [JsonProperty("events")]
+        [JsonProperty("Events")]
         public IList<MaintenanceEvent> MaintenanceEvents { get; set; }
+
+        public string ReportingVmId { get; set; }
 
         public MaintenanceSchedule() { }
 
@@ -27,6 +29,7 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
         {
             DocumentIncarnation = other.DocumentIncarnation;
             MaintenanceEvents = other.MaintenanceEvents.Select((e) => new MaintenanceEvent(e)).ToList();
+            ReportingVmId = other.ReportingVmId;
         }
     }
 
@@ -40,7 +43,7 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
 
         public string ResourceType { get; set; }
 
-        [JsonProperty("resources")]
+        [JsonProperty("Resources")]
         public IList<string> AffectedResources { get; set; }
 
         public string EventStatus { get; set; }

--- a/AgentInterfaces/MaintenanceSchedule.cs
+++ b/AgentInterfaces/MaintenanceSchedule.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
     {
         public string DocumentIncarnation { get; set; }
 
-        [JsonProperty("Events")]
+        [JsonProperty("events")]
         public IList<MaintenanceEvent> MaintenanceEvents { get; set; }
 
         public MaintenanceSchedule() { }
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
 
         public string ResourceType { get; set; }
 
-        [JsonProperty("Resources")]
+        [JsonProperty("resources")]
         public IList<string> AffectedResources { get; set; }
 
         public string EventStatus { get; set; }

--- a/LocalMultiplayerAgent.UnitTest/ControllerTests.cs
+++ b/LocalMultiplayerAgent.UnitTest/ControllerTests.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Azure.Gaming.VmAgent.UnitTests
 
             string sessionHostId = "testSessionHostId";
 
+            // Settings is accessed in the heartbeat endpoint
             Globals.Settings = new();
 
             // send the first heartbeat with "StandingBy"

--- a/LocalMultiplayerAgent.UnitTest/ControllerTests.cs
+++ b/LocalMultiplayerAgent.UnitTest/ControllerTests.cs
@@ -30,6 +30,8 @@ namespace Microsoft.Azure.Gaming.VmAgent.UnitTests
 
             string sessionHostId = "testSessionHostId";
 
+            Globals.Settings = new();
+
             // send the first heartbeat with "StandingBy"
             SessionHostHeartbeatInfo heartbeat = new SessionHostHeartbeatInfo()
             {

--- a/LocalMultiplayerAgent/Config/MultiplayerSettings.cs
+++ b/LocalMultiplayerAgent/Config/MultiplayerSettings.cs
@@ -30,6 +30,8 @@ namespace Microsoft.Azure.Gaming.LocalMultiplayerAgent.Config
 
         public int NumHeartBeatsForTerminateResponse { get; set; }
 
+        public int NumHeartBeatsForMaintenanceEventResponse { get; set; }
+
         public bool RunContainer { get; set; }
 
         public string OutputFolder { get; set; }
@@ -48,6 +50,12 @@ namespace Microsoft.Azure.Gaming.LocalMultiplayerAgent.Config
         public bool ForcePullFromAcrOnLinuxContainersOnWindows { get; set; }
 
         public IDictionary<string, string> DeploymentMetadata { get; set; }
+
+        public string MaintenanceEventType { get; set; }
+
+        public string MaintenanceEventStatus { get; set; }
+
+        public string MaintenanceEventSource { get; set; }
 
         public SessionHostsStartInfo ToSessionHostsStartInfo()
         {

--- a/LocalMultiplayerAgent/Config/MultiplayerSettingsValidator.cs
+++ b/LocalMultiplayerAgent/Config/MultiplayerSettingsValidator.cs
@@ -104,6 +104,12 @@ namespace Microsoft.Azure.Gaming.LocalMultiplayerAgent.Config
                     Console.WriteLine("NumHeartBeatsForTerminateResponse must be greater than NumHeartBeatsForActivateResponse. Ideally more than 1, since you would like the server to be alive for a few seconds");
                     isSuccess = false;
                 }
+
+                if (_settings.NumHeartBeatsForTerminateResponse < _settings.NumHeartBeatsForMaintenanceEventResponse)
+                {
+                    Console.WriteLine("NumHeartBeatsForMaintenanceEventResponse must be less than or equal to NumHeartBeatsForTerminateResponse.");
+                    isSuccess = false;
+                }
             }
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))

--- a/LocalMultiplayerAgent/MultiplayerSettings.json
+++ b/LocalMultiplayerAgent/MultiplayerSettings.json
@@ -2,8 +2,13 @@
     "RunContainer": false,
     "OutputFolder": "",
     "NumHeartBeatsForActivateResponse": 10,
+    "NumHeartBeatsForMaintenanceEventResponse": 0, // a value < 1 will disable the maintenance event
     "NumHeartBeatsForTerminateResponse": 60,
     "AgentListeningPort": 56001,
+    // Valid maintenance event values are explained here: https://learn.microsoft.com/azure/virtual-machines/windows/scheduled-events#event-properties
+    "MaintenanceEventType": "Reboot",
+    "MaintenanceEventStatus": "Scheduled",
+    "MaintenanceEventSource": "Platform",
     "AssetDetails": [
         {
             "MountPath": "C:\\Assets",


### PR DESCRIPTION
Aligns maintenance schedule to final schema and adds event simulation with json config values (disabled by default).