### PR TITLE
Add MPS Secrets as Env Variables in Game Servers

### DIFF
--- a/VmAgent.Core.UnitTests/VmConfigurationTests.cs
+++ b/VmAgent.Core.UnitTests/VmConfigurationTests.cs
@@ -129,6 +129,30 @@ namespace VmAgent.Core.UnitTests
             envVariables.Should().Contain("PF_PUBLIC_IP_ADDRESSES_ROUTING_TYPE_1", "Microsoft");
         }
 
+        [TestMethod]
+        [TestCategory("BVT")]
+        public void EnvironmentVariablesWithMpsSecrets()
+        {
+            SessionHostsStartInfo sessionHostsStartInfo = CreateSessionHostStartInfo(new Dictionary<string, string>());
+            sessionHostsStartInfo.GameSecrets = new SecretDetail[]
+            {
+                new SecretDetail()
+                {
+                    Name = "secret1",
+                    Value = "value1"
+                },
+                new SecretDetail()
+                {
+                    Name = "secret2",
+                    Value = "value2"
+                }
+            };
+
+            IDictionary<string, string> envVariables = VmConfiguration.GetCommonEnvironmentVariables(sessionHostsStartInfo, VmConfiguration);
+            envVariables.Should().Contain("PF_MPS_SECRET_secret1", "value1");
+            envVariables.Should().Contain("PF_MPS_SECRET_secret2", "value2");
+        }
+
 
         private SessionHostsStartInfo CreateSessionHostStartInfo(IDictionary<string, string> buildMetadata = null, SessionHostType sessionHostType = SessionHostType.Process)
         {

--- a/VmAgent.Core/VmConfiguration.cs
+++ b/VmAgent.Core/VmConfiguration.cs
@@ -54,6 +54,9 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core
         /// Prefix used for all the Public Ip Addresses environment variables (count, ip addresss, fqdn, routing type)
         public const string PublicIpAddressesEnvVariablePrefix = "PF_PUBLIC_IP_ADDRESSES";
 
+        // Prefix for each secret configured in PlayFab MPS and saved as environment variable
+        public const string PlayfabMpsSecretEnvVariablePrefix = "PF_MPS_SECRET";
+
         private static readonly byte[] PlayFabTitleIdPrefix = BitConverter.GetBytes(0xFFFFFFFFFFFFFFFF);
 
         public int ListeningPort { get; }
@@ -117,6 +120,8 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core
 
             environmentVariables.AddRange(GetPublicIpAddressesEnvironmentVariables(sessionHostsStartInfo));
 
+            environmentVariables.AddRange(GetEnvironmentVariablesWithPlayFabMpsSecrets(sessionHostsStartInfo));
+
             return environmentVariables;
         }
 
@@ -146,6 +151,12 @@ namespace Microsoft.Azure.Gaming.VmAgent.Core
             }    
 
             return publicIPAddressesEnvironmentVariables;
+        }
+
+        private static IDictionary<string, string> GetEnvironmentVariablesWithPlayFabMpsSecrets(SessionHostsStartInfo sessionHostsStartInfo)
+        {
+            return sessionHostsStartInfo.GameSecrets?.ToDictionary(
+                secretDetail => $"{PlayfabMpsSecretEnvVariablePrefix}_{secretDetail.Name}", secretDetail => secretDetail.Value) ?? new Dictionary<string, string>();
         }
 
         private static string GetSharedContentFolderPath(SessionHostsStartInfo sessionHostsStartInfo, VmConfiguration vmConfiguration)


### PR DESCRIPTION
Adding the MPS Secrets as Environment Variables in Game Servers. They will also be accessed by the VMStartupScript once we update the nuget package in VMAgent