### PR TITLE
Remove unused Serializable attribute (and update AgentInterfaces to net8.0)

### DIFF
--- a/AgentInterfaces/AgentInterfaces.csproj
+++ b/AgentInterfaces/AgentInterfaces.csproj
@@ -1,6 +1,6 @@
 ﻿ <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <RootNamespace>Microsoft.Azure.Gaming.AgentInterfaces</RootNamespace>
   </PropertyGroup>
   <PropertyGroup>

--- a/AgentInterfaces/AssignmentData.cs
+++ b/AgentInterfaces/AssignmentData.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
     using System.Collections.Generic;
     using System.Linq;
 
-    [Serializable]
     public class AssignmentData
     {
         public ConcurrentDictionary<string, SessionHostHeartbeatInfo> SessionHostHeartbeatMap { get; set; }

--- a/AgentInterfaces/MaintenanceSchedule.cs
+++ b/AgentInterfaces/MaintenanceSchedule.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
     using Newtonsoft.Json.Converters;
 
     // Data Format: https://docs.microsoft.com/en-us/azure/virtual-machines/windows/scheduled-events
-    [Serializable]
     public class MaintenanceSchedule
     {
         public string DocumentIncarnation { get; set; }
@@ -34,7 +33,6 @@ namespace Microsoft.Azure.Gaming.AgentInterfaces
     }
 
     // https://docs.microsoft.com/en-us/azure/virtual-machines/windows/scheduled-events#query-for-events
-    [Serializable]
     public class MaintenanceEvent
     {
         public string EventId { get; set; }

--- a/VmAgent.Core/Dependencies/Interfaces/Exceptions/AssetExtractionFailedException.cs
+++ b/VmAgent.Core/Dependencies/Interfaces/Exceptions/AssetExtractionFailedException.cs
@@ -5,7 +5,6 @@ using System.Text;
 
 namespace VmAgent.Core.Dependencies.Interfaces.Exceptions
 {
-    [Serializable]
     public class AssetExtractionFailedException : Exception
     {
         public AssetExtractionFailedException(string message) : base(message)

--- a/VmAgent.Core/Dependencies/Interfaces/Exceptions/ProcessOutputLoggerCreationFailedException.cs
+++ b/VmAgent.Core/Dependencies/Interfaces/Exceptions/ProcessOutputLoggerCreationFailedException.cs
@@ -5,7 +5,6 @@ using System.Text;
 
 namespace VmAgent.Core.Dependencies.Interfaces.Exceptions
 {
-    [Serializable]
     public class ProcessOuputLoggerCreationFailedException : Exception
     {
         public ProcessOuputLoggerCreationFailedException(string message) : base(message)


### PR DESCRIPTION
**Remove unused Serializable attribute (and update AgentInterfaces to net8.0)**

[Serializable] is not used by modern serializers